### PR TITLE
Add kotlinx-metadata based reflect artifact for Moshi Sealed

### DIFF
--- a/moshi-sealed/README.md
+++ b/moshi-sealed/README.md
@@ -141,6 +141,26 @@ Gradle dependency:
 implementation "dev.zacsweers.moshix:moshi-sealed-reflect:{version}"
 ```
 
+#### kotlinx-metadata based reflection
+
+You can also use the kotlinx-metadata based version of reflection artifact, which cuts off the cost
+of including kotlin-reflect. In your moshi instance construction, use
+`MetadataMoshiSealedJsonAdapterFactory`:
+
+```kotlin
+val moshi = Moshi.Builder()
+    .add(MetadataMoshiSealedJsonAdapterFactory())
+    .add(KotlinJsonAdapterFactory())
+    .build()
+```
+
+Gradle dependency:
+
+[![Maven Central](https://img.shields.io/maven-central/v/dev.zacsweers.moshix/moshi-sealed-metadata-reflect.svg)](https://mvnrepository.com/artifact/dev.zacsweers.moshix/moshi-sealed-metadata-reflect)
+```gradle
+implementation "dev.zacsweers.moshix:moshi-sealed-metadata-reflect:{version}"
+```
+
 Snapshots of the development version are available in [Sonatype's snapshots repository][snapshots].
 
 License

--- a/moshi-sealed/metadata-reflect/build.gradle.kts
+++ b/moshi-sealed/metadata-reflect/build.gradle.kts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  kotlin("jvm")
+  id("com.vanniktech.maven.publish")
+}
+
+dependencies {
+  implementation(project(":moshi-sealed:runtime"))
+  api(Dependencies.Moshi.moshi)
+  api(Dependencies.Moshi.adapters)
+  implementation(Dependencies.Kotlin.metadata)
+}

--- a/moshi-sealed/metadata-reflect/gradle.properties
+++ b/moshi-sealed/metadata-reflect/gradle.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2021 Zac Sweers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+POM_NAME=Moshi-Sealed-Metadata-Reflect
+POM_ARTIFACT_ID=moshi-sealed-metadata-reflect
+POM_PACKAGING=jar

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -75,9 +75,9 @@ public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
             }
           }
         } else {
-          val labelAnnotation = sealedSubclass.getAnnotation(TypeLabel::class.java)
-            ?: throw IllegalArgumentException(
-              "Sealed subtypes must be annotated with @TypeLabel to define their label $sealedSubclass")
+          val labelAnnotation = checkNotNull(sealedSubclass.getAnnotation(TypeLabel::class.java)) {
+            "Sealed subtypes must be annotated with @TypeLabel to define their label $sealedSubclass"
+          }
           val label = labelAnnotation.label
           labels[label] = sealedSubclass
           for (alternate in labelAnnotation.alternateLabels) {

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -30,13 +30,15 @@ public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
     }
     val rawType = Types.getRawType(type)
     if (!rawType.isAnnotationPresent(KOTLIN_METADATA)) return null
-    val kmClass = rawType.header()?.toKmClass() ?: return null
 
     rawType.getAnnotation(JsonClass::class.java)?.let { jsonClass ->
       val generator = jsonClass.generator
       if (!generator.startsWith("sealed:")) {
         return null
       }
+
+      val kmClass = rawType.header()?.toKmClass() ?: return null
+
       val typeLabel = generator.removePrefix("sealed:")
       if (!Flag.IS_SEALED(kmClass.flags)) {
         return null

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -1,0 +1,152 @@
+package dev.zacsweers.moshix.sealed.reflect
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+import dev.zacsweers.moshix.sealed.annotations.DefaultNull
+import dev.zacsweers.moshix.sealed.annotations.DefaultObject
+import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+import dev.zacsweers.moshix.sealed.runtime.internal.ObjectJsonAdapter
+import kotlinx.metadata.ClassName
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.jvm.KotlinClassHeader
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import java.lang.reflect.Type
+
+/** Classes annotated with this are eligible for this adapter. */
+private val KOTLIN_METADATA = Metadata::class.java
+
+private val UNSET = Any()
+
+public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
+  override fun create(type: Type,
+                      annotations: MutableSet<out Annotation>,
+                      moshi: Moshi): JsonAdapter<*>? {
+    if (annotations.isNotEmpty()) {
+      return null
+    }
+    val rawType = Types.getRawType(type)
+    if (!rawType.isAnnotationPresent(KOTLIN_METADATA)) return null
+    val kmClass = rawType.header()?.toKmClass() ?: return null
+
+    rawType.getAnnotation(JsonClass::class.java)?.let { jsonClass ->
+      val generator = jsonClass.generator
+      if (!generator.startsWith("sealed:")) {
+        return null
+      }
+      val typeLabel = generator.removePrefix("sealed:")
+      if (!Flag.IS_SEALED(kmClass.flags)) {
+        return null
+      }
+
+      // Pull out the default instance as necessary
+      // Possible cases:
+      //   - No default (error if missing at runtime)
+      //   - Null default
+      //   - Object default
+      var defaultObjectInstance: Any? = UNSET
+      if (rawType.isAnnotationPresent(DefaultNull::class.java)) {
+        defaultObjectInstance = null
+      }
+
+      val objectSubtypes = mutableMapOf<Class<*>, Any>()
+      val labels = mutableMapOf<String, Class<*>>()
+      for (sealedSubclassName in kmClass.sealedSubclasses) {
+        val sealedSubclass = sealedSubclassName.toJavaClass()
+        val kmSealedSubclass = sealedSubclass.header()?.toKmClass() ?: return null
+        val isObject = Flag.Class.IS_OBJECT(kmSealedSubclass.flags)
+
+        val isAnnotatedDefaultObject = sealedSubclass.isAnnotationPresent(DefaultObject::class.java)
+        if (isAnnotatedDefaultObject) {
+          if (!isObject) {
+            error("Must be an object type to use as a @DefaultObject: $sealedSubclass")
+          } else if (defaultObjectInstance === UNSET) {
+            defaultObjectInstance = sealedSubclass.objectInstance()
+          } else {
+            if (defaultObjectInstance == null) {
+              error("Can not have both @DefaultObject and @DefaultNull: $sealedSubclass")
+            } else {
+              error("Can only have one @DefaultObject: $sealedSubclass and ${defaultObjectInstance.javaClass} are both annotated")
+            }
+          }
+        } else {
+          val labelAnnotation = sealedSubclass.getAnnotation(TypeLabel::class.java)
+            ?: throw IllegalArgumentException(
+              "Sealed subtypes must be annotated with @TypeLabel to define their label $sealedSubclass")
+          val label = labelAnnotation.label
+          labels[label] = sealedSubclass
+          for (alternate in labelAnnotation.alternateLabels) {
+            labels[alternate] = sealedSubclass
+          }
+          if (isObject) {
+            objectSubtypes[sealedSubclass] = sealedSubclass.objectInstance()
+          }
+        }
+      }
+
+      val delegateMoshi = if (objectSubtypes.isEmpty()) {
+        moshi
+      } else {
+        moshi.newBuilder()
+          .apply {
+            for ((subtype, instance) in objectSubtypes) {
+              add(subtype, ObjectJsonAdapter(instance))
+            }
+          }
+          .build()
+      }
+
+      @Suppress("UNCHECKED_CAST")
+      val seed = PolymorphicJsonAdapterFactory.of(rawType as Class<Any>?, typeLabel)
+      val polymorphicFactory = labels.entries
+        .fold(seed) { factory, (label, subtype) ->
+          factory.withSubtype(subtype, label)
+        }
+        .let { factory ->
+          if (defaultObjectInstance !== UNSET) {
+            factory.withDefaultValue(defaultObjectInstance)
+          } else {
+            factory
+          }
+        }
+
+      return polymorphicFactory.create(rawType, annotations, delegateMoshi)
+    }
+    return null
+  }
+}
+
+private fun Class<*>.header(): KotlinClassHeader? {
+  val metadata = getAnnotation(KOTLIN_METADATA) ?: return null
+  return with(metadata) {
+    KotlinClassHeader(
+      kind = kind,
+      metadataVersion = metadataVersion,
+      bytecodeVersion = bytecodeVersion,
+      data1 = data1,
+      data2 = data2,
+      extraString = extraString,
+      packageName = packageName,
+      extraInt = extraInt
+    )
+  }
+}
+
+private fun KotlinClassHeader.toKmClass(): KmClass? {
+  val classMetadata = KotlinClassMetadata.read(this)
+  if (classMetadata !is KotlinClassMetadata.Class) {
+    return null
+  }
+  return classMetadata.toKmClass()
+}
+
+private fun ClassName.toJavaClass(): Class<*> {
+  return Class.forName(replace(".", "$").replace("/", "."))
+}
+
+private fun Class<*>.objectInstance(): Any {
+  return getDeclaredField("INSTANCE").get(null)
+}

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -37,7 +37,7 @@ public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
         return null
       }
 
-      val kmClass = rawType.header()?.toKmClass() ?: return null
+      val kmClass = checkNotNull(rawType.header()?.toKmClass())
 
       val typeLabel = generator.removePrefix("sealed:")
       if (!Flag.IS_SEALED(kmClass.flags)) {
@@ -58,7 +58,7 @@ public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
       val labels = mutableMapOf<String, Class<*>>()
       for (sealedSubclassName in kmClass.sealedSubclasses) {
         val sealedSubclass = sealedSubclassName.toJavaClass()
-        val kmSealedSubclass = sealedSubclass.header()?.toKmClass() ?: return null
+        val kmSealedSubclass = checkNotNull(sealedSubclass.header()?.toKmClass())
         val isObject = Flag.Class.IS_OBJECT(kmSealedSubclass.flags)
 
         val isAnnotatedDefaultObject = sealedSubclass.isAnnotationPresent(DefaultObject::class.java)

--- a/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-sealed-metadata-reflect.pro
+++ b/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/proguard/moshi-sealed-metadata-reflect.pro
@@ -1,0 +1,16 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/r8-from-1.6.0/moshi-sealed-metadata-reflect.pro
+# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-sealed-metadata-reflect.pro
+# - META-INF/proguard/moshi-sealed-metadata-reflect.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep implementations of service loaded interfaces
+-keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions
+-keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }
+
+# Keep generic signatures and annotations at runtime.
+-keepattributes Signature,RuntimeVisible*Annotations

--- a/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-sealed-metadata-reflect.pro
+++ b/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/r8-from-1.6.0/moshi-sealed-metadata-reflect.pro
@@ -1,0 +1,13 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/proguard/moshi-sealed-metadata-reflect.pro
+# - META-INF/com.android.tools/r8-upto-1.6.0/moshi-sealed-metadata-reflect.pro
+# - META-INF/proguard/moshi-sealed-metadata-reflect.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep generic signatures and annotations at runtime.
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-sealed-metadata-reflect.pro
+++ b/moshi-sealed/metadata-reflect/src/main/resources/META-INF/com.android.tools/r8-upto-1.6.0/moshi-sealed-metadata-reflect.pro
@@ -1,0 +1,18 @@
+# When editing this file, update the following files as well:
+# - META-INF/com.android.tools/proguard/moshi-sealed-metadata-reflect.pro
+# - META-INF/com.android.tools/r8-from-1.6.0/moshi-sealed-metadata-reflect.pro
+# - META-INF/proguard/moshi-sealed-metadata-reflect.pro
+# Keep Metadata annotations so they can be parsed at runtime.
+-keep class kotlin.Metadata { *; }
+
+# Keep default constructor marker name for lookup in signatures.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+
+# Keep implementations of service loaded interfaces
+# R8 will automatically handle these these in 1.6+
+-keep interface com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions
+-keep class * implements com.squareup.moshi.kotlin.kotlinx.metadata.impl.extensions.MetadataExtensions { public protected *; }
+
+# Keep generic signatures and annotations at runtime.
+# R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.
+-keepattributes InnerClasses,Signature,RuntimeVisible*Annotations,EnclosingMethod

--- a/moshi-sealed/sample/build.gradle.kts
+++ b/moshi-sealed/sample/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(project(":moshi-sealed:runtime"))
   implementation(Dependencies.Moshi.kotlin)
   implementation(project(":moshi-sealed:reflect"))
+  implementation(project(":moshi-sealed:metadata-reflect"))
 
   if (!useKsp) {
     kaptTest(project(":moshi-sealed:codegen"))

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/MessageTest.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/MessageTest.kt
@@ -8,6 +8,7 @@ import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.annotations.DefaultNull
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+import dev.zacsweers.moshix.sealed.reflect.MetadataMoshiSealedJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.reflect.MoshiSealedJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.sample.Message
 import org.junit.Test
@@ -27,6 +28,13 @@ class MessageTest(type: Type) {
             .build()
     )
     ,
+    METADATA_REFLECT(
+        moshi = Moshi.Builder()
+            .add(MetadataMoshiSealedJsonAdapterFactory())
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+    )
+    ,
     CODEGEN
   }
 
@@ -36,6 +44,7 @@ class MessageTest(type: Type) {
     fun data(): Collection<Array<*>> {
       return listOf(
           arrayOf(Type.REFLECT),
+          arrayOf(Type.METADATA_REFLECT),
           arrayOf(Type.CODEGEN)
       )
     }

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ObjectSerializationTest.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ObjectSerializationTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.zacsweers.moshix.sealed.reflect.MetadataMoshiSealedJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.reflect.MoshiSealedJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.sample.FunctionSpec
 import dev.zacsweers.moshix.sealed.sample.Type.BooleanType
@@ -25,6 +26,13 @@ class ObjectSerializationTest(type: Type) {
         .build()
     )
     ,
+    METADATA_REFLECT(
+      moshi = Moshi.Builder()
+        .add(MetadataMoshiSealedJsonAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+    )
+    ,
     CODEGEN
   }
 
@@ -34,6 +42,7 @@ class ObjectSerializationTest(type: Type) {
     fun data(): Collection<Array<*>> {
       return listOf(
         arrayOf(Type.REFLECT),
+        arrayOf(Type.METADATA_REFLECT),
         arrayOf(Type.CODEGEN)
       )
     }

--- a/moshi-sealed/sealed-interfaces-samples/kotlin/build.gradle.kts
+++ b/moshi-sealed/sealed-interfaces-samples/kotlin/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(project(":moshi-sealed:runtime"))
   implementation(Dependencies.Moshi.kotlin)
   implementation(project(":moshi-sealed:reflect"))
+  implementation(project(":moshi-sealed:metadata-reflect"))
 
 //  if (!useKsp) {
   kaptTest(project(":moshi-sealed:codegen"))

--- a/moshi-sealed/sealed-interfaces-samples/kotlin/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/interfaces/MessageTest.kt
+++ b/moshi-sealed/sealed-interfaces-samples/kotlin/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/interfaces/MessageTest.kt
@@ -23,6 +23,7 @@ import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.annotations.DefaultNull
 import dev.zacsweers.moshix.sealed.annotations.TypeLabel
+import dev.zacsweers.moshix.sealed.reflect.MetadataMoshiSealedJsonAdapterFactory
 import dev.zacsweers.moshix.sealed.reflect.MoshiSealedJsonAdapterFactory
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,6 +41,12 @@ class MessageTest(type: Type) {
         .addLast(KotlinJsonAdapterFactory())
         .build()
     ),
+    METADATA_REFLECT(
+      moshi = Moshi.Builder()
+        .add(MetadataMoshiSealedJsonAdapterFactory())
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+    ),
     CODEGEN
   }
 
@@ -49,6 +56,7 @@ class MessageTest(type: Type) {
     fun data(): Collection<Array<*>> {
       return listOf(
         arrayOf(Type.REFLECT),
+        arrayOf(Type.METADATA_REFLECT),
         arrayOf(Type.CODEGEN)
       )
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,7 @@ include("moshi-sealed:runtime")
 include("moshi-sealed:codegen")
 include("moshi-sealed:codegen-ksp")
 include("moshi-sealed:reflect")
+include("moshi-sealed:metadata-reflect")
 include("moshi-sealed:sample")
 include("moshi-sealed:sample")
 


### PR DESCRIPTION
This adds `:moshi-sealed:metadata-reflect` project, which is based on the `:moshi-sealed:reflect`, but uses kotlinx-metadata instead of kotlin-reflect. 

Kotlin metadata is used to check if processed class is a sealed class, and to check if a class annotated with `@DefaultObject` is an object. In other places, like obtaining annotations or object instance, Java APIs are used; couldn't find a decent way to do those things without kotlin-reflect.

Fixes #55 