### PR TITLE
Mention `com.google.devtools.ksp` in the KSP README

### DIFF
--- a/moshi-ksp/README.md
+++ b/moshi-ksp/README.md
@@ -10,6 +10,10 @@ Add this dependency as a `ksp` dependency instead of the `moshi-kotlin-codegen` 
 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.zacsweers.moshix/moshi-ksp.svg)](https://mvnrepository.com/artifact/dev.zacsweers.moshix/moshi-ksp)
 ```diff
+plugins {
++  id("com.google.devtools.ksp").version("<version>")
+}
+
 dependencies {
 -  kapt("com.squareup.moshi:moshi-kotlin-codegen:<version>")
 +  ksp("dev.zacsweers.moshix:moshi-ksp:<version>")

--- a/moshi-ksp/README.md
+++ b/moshi-ksp/README.md
@@ -11,6 +11,7 @@ Add this dependency as a `ksp` dependency instead of the `moshi-kotlin-codegen` 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.zacsweers.moshix/moshi-ksp.svg)](https://mvnrepository.com/artifact/dev.zacsweers.moshix/moshi-ksp)
 ```diff
 plugins {
+- kotlin("kapt")
 +  id("com.google.devtools.ksp").version("<version>")
 }
 


### PR DESCRIPTION
It looks like there is also a `kotlin-ksp` plugin too? Not really sure what that is but I believe `com.google.devtools.ksp` is the correct one so adding it explicitly should clear the confusion. Also makes it explicit that the plugin needs to be applied in the first place.