### PR TITLE
Let @AdaptedBy support custom Adapter definition

### DIFF
--- a/moshi-adapters/src/main/kotlin/com/squareup/moshi/AdapterMethodFactoryCompat.kt
+++ b/moshi-adapters/src/main/kotlin/com/squareup/moshi/AdapterMethodFactoryCompat.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2021 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.moshi
+
+/**
+ * Creates a [JsonAdapter.Factory] from the class information.
+ */
+internal fun createCustomAdapter(adapter: Class<*>): JsonAdapter.Factory {
+  return AdapterMethodsFactory.get(adapter.getDeclaredConstructor().newInstance())
+}

--- a/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/AdaptedBy.kt
+++ b/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/AdaptedBy.kt
@@ -18,6 +18,7 @@ package dev.zacsweers.moshix.adapters
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonQualifier
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.createCustomAdapter
 import com.squareup.moshi.rawType
 import java.lang.reflect.Type
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -114,10 +115,8 @@ public annotation class AdaptedBy(
             .newInstance() as JsonAdapter<*>
         }
         else -> {
-          error(
-            "Invalid attempt to bind an instance of ${javaClass.name} as a @AdaptedBy for $type. @AdaptedBy " +
-              "value must be a JsonAdapter or JsonAdapter.Factory."
-          )
+          val factory = createCustomAdapter(javaClass)
+          factory.create(type, nextAnnotations.orEmpty(), moshi)
         }
       } ?: return null
 


### PR DESCRIPTION
Fix https://github.com/ZacSweers/MoshiX/issues/110

Using `AdapterMethodsFactory` to create custom JsonAdapter.Factory for the class declared in the `@AdaptedBy` annotation.