### PR TITLE
Recognize KOTLIN_LIB origins as also kotlin types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
 apiValidation {
   ignoredProjects.addAll(
     listOf(
+      /* :moshi-ksp: */ "extra-moshi-test-module",
       /* :moshi-ksp: */ "tests",
       /* :moshi-sealed: */ "sample"
     )
@@ -140,7 +141,7 @@ subprojects {
 //        allWarningsAsErrors = true
       }
     }
-    if (project.name != "sample" && !project.path.contains("sample")) {
+    if (project.name != "sample" && !project.path.contains("sample") && !project.path.contains("test")) {
       configure<KotlinProjectExtension> {
         explicitApi()
       }

--- a/moshi-ksp/extra-moshi-test-module/build.gradle.kts
+++ b/moshi-ksp/extra-moshi-test-module/build.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2021 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  kotlin("jvm")
+}

--- a/moshi-ksp/extra-moshi-test-module/src/main/kotlin/dev/zacsweers/moshix/ksp/test/extra/AbstractClassInModuleA.kt
+++ b/moshi-ksp/extra-moshi-test-module/src/main/kotlin/dev/zacsweers/moshix/ksp/test/extra/AbstractClassInModuleA.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.zacsweers.moshix.ksp.test.extra
 
 abstract class AbstractClassInModuleA

--- a/moshi-ksp/extra-moshi-test-module/src/main/kotlin/dev/zacsweers/moshix/ksp/test/extra/AbstractClassInModuleA.kt
+++ b/moshi-ksp/extra-moshi-test-module/src/main/kotlin/dev/zacsweers/moshix/ksp/test/extra/AbstractClassInModuleA.kt
@@ -1,0 +1,3 @@
+package dev.zacsweers.moshix.ksp.test.extra
+
+abstract class AbstractClassInModuleA

--- a/moshi-ksp/moshi-ksp/src/main/kotlin/dev/zacsweers/moshix/ksp/KspUtil.kt
+++ b/moshi-ksp/moshi-ksp/src/main/kotlin/dev/zacsweers/moshix/ksp/KspUtil.kt
@@ -28,6 +28,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.Origin.KOTLIN
+import com.google.devtools.ksp.symbol.Origin.KOTLIN_LIB
 import com.google.devtools.ksp.symbol.Visibility
 import com.google.devtools.ksp.symbol.Visibility.INTERNAL
 import com.google.devtools.ksp.symbol.Visibility.JAVA_PACKAGE
@@ -59,6 +60,7 @@ internal fun KSClassDeclaration.superclass(resolver: Resolver): KSType {
 
 internal fun KSClassDeclaration.isKotlinClass(resolver: Resolver): Boolean {
   return origin == KOTLIN ||
+    origin == KOTLIN_LIB ||
     hasAnnotation(resolver.getClassDeclarationByName<Metadata>().asType())
 }
 

--- a/moshi-ksp/moshi-ksp/src/main/kotlin/dev/zacsweers/moshix/ksp/TargetTypes.kt
+++ b/moshi-ksp/moshi-ksp/src/main/kotlin/dev/zacsweers/moshix/ksp/TargetTypes.kt
@@ -98,8 +98,12 @@ internal fun targetType(
     val classDecl = supertype.type
     if (!classDecl.isKotlinClass(resolver)) {
       logger.error(
-        "@JsonClass can't be applied to $type: supertype $supertype is not a Kotlin type.",
-          type
+        """
+        @JsonClass can't be applied to $type: supertype $supertype is not a Kotlin type.
+        Origin=${classDecl.origin}
+        Annotations=${classDecl.annotations.joinToString(prefix = "[", postfix = "]") { it.shortName.getShortName() }}
+        """.trimIndent(),
+        type
       )
       return null
     }

--- a/moshi-ksp/tests/build.gradle.kts
+++ b/moshi-ksp/tests/build.gradle.kts
@@ -37,6 +37,7 @@ sourceSets {
 
 dependencies {
   kspTest(project(":moshi-ksp:moshi-ksp"))
+  testImplementation(project(":moshi-ksp:extra-moshi-test-module"))
   testImplementation(Dependencies.Moshi.moshi)
   testImplementation(project(":moshi-metadata-reflect"))
   testImplementation(Dependencies.Testing.junit)

--- a/moshi-ksp/tests/src/test/kotlin/dev/zacsweers/moshix/ksp/DualKotlinTest.kt
+++ b/moshi-ksp/tests/src/test/kotlin/dev/zacsweers/moshix/ksp/DualKotlinTest.kt
@@ -27,6 +27,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.ToJson
 import com.squareup.moshi.Types
 import com.squareup.moshi.adapter
+import dev.zacsweers.moshix.ksp.test.extra.AbstractClassInModuleA
 import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.fail
@@ -671,3 +672,9 @@ data class ClassWithQualifier(
   @UpperCase(foo = [Foo.BAR])
   val a: Int
 )
+
+// Regression for https://github.com/ZacSweers/MoshiX/issues/120
+@JsonClass(generateAdapter = true)
+data class DataClassInModuleB(
+  val id : String
+) : AbstractClassInModuleA()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ pluginManagement {
 
 rootProject.name = "moshix-root"
 include(":moshi-adapters")
+include(":moshi-ksp:extra-moshi-test-module")
 include(":moshi-ksp:moshi-ksp")
 include(":moshi-ksp:tests")
 include(":moshi-metadata-reflect")


### PR DESCRIPTION
Resolves #120. I think this is the right thing to do but I've also asked in the ksp channel on kotlin-lang to clarify