### PR TITLE
Generate proguard rules

### DIFF
--- a/moshi-ir/README.md
+++ b/moshi-ir/README.md
@@ -17,19 +17,6 @@ embedded IR plugin.
   - See https://github.com/square/moshi/issues/836 for more details!
 
 **Cons**
-- No support for Proguard file generation for now [#193](https://github.com/ZacSweers/MoshiX/issues/193). You will
-  need to add this manually to your rules if you use R8/Proguard.
-  - One option is to use IR in debug builds and Kapt/KSP in release builds, the latter of which do still generate
-    proguard rules.
-  ```proguard
-  # Keep names for JsonClass-annotated classes
-  -keepnames @com.squareup.moshi.JsonClass class **
-
-  # Keep generated adapter classes' constructors
-  -keepclassmembers class *JsonAdapter {
-      public <init>(...);
-  }
-  ```
 - Kotlin IR is not a stable API and may change in future Kotlin versions. While I'll try to publish quickly to adjust to
 these, you should be aware. If you have any issues, you can always fall back to Kapt/KSP.
 

--- a/moshi-ir/moshi-compiler-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-compiler-plugin/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
   compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.10")
   implementation("com.google.auto.service:auto-service-annotations:1.0.1")
   implementation("com.squareup.moshi:moshi:1.13.0")
+  implementation("com.squareup:kotlinpoet:1.10.2")
+  implementation("com.squareup.moshi:moshi-kotlin-codegen:1.13.0")
   ksp("dev.zacsweers.autoservice:auto-service-ksp:1.0.0")
 
   testImplementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiCommandLineProcessor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiCommandLineProcessor.kt
@@ -23,8 +23,12 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 internal val KEY_ENABLED = CompilerConfigurationKey<Boolean>("enabled")
+internal val KEY_DEBUG = CompilerConfigurationKey<Boolean>("debug")
 internal val KEY_GENERATED_ANNOTATION = CompilerConfigurationKey<String>("generatedAnnotation")
 internal val KEY_ENABLE_SEALED = CompilerConfigurationKey<Boolean>("enableSealed")
+internal val KEY_GENERATE_PROGUARD_RULES =
+    CompilerConfigurationKey<Boolean>("generateProguardRules")
+internal val KEY_RESOURCES_OUTPUT_DIR = CompilerConfigurationKey<String>("resourcesOutputDir")
 
 @AutoService(CommandLineProcessor::class)
 public class MoshiCommandLineProcessor : CommandLineProcessor {
@@ -34,8 +38,11 @@ public class MoshiCommandLineProcessor : CommandLineProcessor {
   override val pluginOptions: Collection<AbstractCliOption> =
       listOf(
           CliOption("enabled", "<true | false>", "", required = true),
+          CliOption("debug", "<true | false>", "", required = false),
           CliOption("enableSealed", "<true | false>", "", required = false),
           CliOption("generatedAnnotation", "String", "", required = false),
+          CliOption("generateProguardRules", "<true | false>", "", required = false),
+          CliOption("resourcesOutputDir", "String", "", required = false),
       )
 
   override fun processOption(
@@ -45,8 +52,11 @@ public class MoshiCommandLineProcessor : CommandLineProcessor {
   ): Unit =
       when (option.optionName) {
         "enabled" -> configuration.put(KEY_ENABLED, value.toBoolean())
+        "debug" -> configuration.put(KEY_DEBUG, value.toBoolean())
         "enableSealed" -> configuration.put(KEY_ENABLE_SEALED, value.toBoolean())
         "generatedAnnotation" -> configuration.put(KEY_GENERATED_ANNOTATION, value)
+        "generateProguardRules" -> configuration.put(KEY_GENERATE_PROGUARD_RULES, value.toBoolean())
+        "resourcesOutputDir" -> configuration.put(KEY_RESOURCES_OUTPUT_DIR, value)
         else -> error("Unknown plugin option: ${option.optionName}")
       }
 }

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiComponentRegistrar.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiComponentRegistrar.kt
@@ -16,13 +16,17 @@
 package dev.zacsweers.moshix.ir.compiler
 
 import com.google.auto.service.AutoService
+import dev.zacsweers.moshix.ir.compiler.proguardgen.ProguardRuleGenerationExtension
+import java.io.File
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.LoadingOrder
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 
 @AutoService(ComponentRegistrar::class)
 public class MoshiComponentRegistrar : ComponentRegistrar {
@@ -33,13 +37,47 @@ public class MoshiComponentRegistrar : ComponentRegistrar {
   ) {
 
     if (configuration[KEY_ENABLED] == false) return
+    val debug = configuration[KEY_DEBUG] ?: false
     val enableSealed = configuration[KEY_ENABLE_SEALED] ?: false
+    val generateProguardRules = configuration[KEY_GENERATE_PROGUARD_RULES] ?: true
 
     val messageCollector =
         configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
     val fqGeneratedAnnotation = configuration[KEY_GENERATED_ANNOTATION]?.let(::FqName)
 
+    if (generateProguardRules) {
+      val resourceOutputDir =
+          configuration.get(KEY_RESOURCES_OUTPUT_DIR)?.let(::File)
+              ?: error("No resources dir provided for proguard rule generation")
+      // It's important to register our extension at the first position. The compiler calls each
+      // extension one by one. If an extension returns a result, then the compiler won't call any
+      // other extension. That usually happens with Kapt in the stub generating task.
+      //
+      // It's not dangerous for our extension to run first, because we generate code, restart the
+      // analysis phase and then don't return a result anymore. That means the next extension can
+      // take over. If we wouldn't do this and any other extension won't let ours run, then we
+      // couldn't generate any code.
+      AnalysisHandlerExtension.registerExtensionFirst(
+          project,
+          ProguardRuleGenerationExtension(
+              messageCollector = messageCollector,
+              resourcesDir = resourceOutputDir,
+              enableSealed = enableSealed,
+              debug = debug))
+    }
+
     IrGenerationExtension.registerExtension(
-        project, MoshiIrGenerationExtension(messageCollector, fqGeneratedAnnotation, enableSealed))
+        project,
+        MoshiIrGenerationExtension(messageCollector, fqGeneratedAnnotation, enableSealed, debug))
   }
+}
+
+private fun AnalysisHandlerExtension.Companion.registerExtensionFirst(
+    project: MockProject,
+    extension: AnalysisHandlerExtension
+) {
+  project
+      .extensionArea
+      .getExtensionPoint(AnalysisHandlerExtension.extensionPointName)
+      .registerExtension(extension, LoadingOrder.FIRST, project)
 }

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
@@ -23,30 +23,33 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.name.FqName
 
 internal class MoshiIrGenerationExtension(
-    private val messageCollector: MessageCollector,
-    private val generatedAnnotationName: FqName?,
-    private val enableSealed: Boolean
+  private val messageCollector: MessageCollector,
+  private val generatedAnnotationName: FqName?,
+  private val enableSealed: Boolean,
+  private val debug: Boolean
 ) : IrGenerationExtension {
 
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
     val generatedAnnotation =
-        generatedAnnotationName?.let { fqName ->
-          pluginContext.referenceClass(fqName).also {
-            if (it == null) {
-              messageCollector.error { "Unknown generated annotation $generatedAnnotationName" }
-              return
-            }
+      generatedAnnotationName?.let { fqName ->
+        pluginContext.referenceClass(fqName).also {
+          if (it == null) {
+            messageCollector.error { "Unknown generated annotation $generatedAnnotationName" }
+            return
           }
         }
+      }
     val deferred = mutableListOf<GeneratedAdapter>()
     val moshiTransformer =
-        MoshiIrVisitor(
-            moduleFragment,
-            pluginContext,
-            messageCollector,
-            generatedAnnotation,
-            enableSealed,
-            deferred)
+      MoshiIrVisitor(
+        moduleFragment,
+        pluginContext,
+        messageCollector,
+        generatedAnnotation,
+        enableSealed,
+        deferred,
+        debug
+      )
     moduleFragment.transform(moshiTransformer, null)
     for ((file, adapters) in deferred.groupBy { it.irFile }) {
       for (adapter in adapters) {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
@@ -23,33 +23,32 @@ import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.name.FqName
 
 internal class MoshiIrGenerationExtension(
-  private val messageCollector: MessageCollector,
-  private val generatedAnnotationName: FqName?,
-  private val enableSealed: Boolean,
-  private val debug: Boolean
+    private val messageCollector: MessageCollector,
+    private val generatedAnnotationName: FqName?,
+    private val enableSealed: Boolean,
+    private val debug: Boolean
 ) : IrGenerationExtension {
 
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
     val generatedAnnotation =
-      generatedAnnotationName?.let { fqName ->
-        pluginContext.referenceClass(fqName).also {
-          if (it == null) {
-            messageCollector.error { "Unknown generated annotation $generatedAnnotationName" }
-            return
+        generatedAnnotationName?.let { fqName ->
+          pluginContext.referenceClass(fqName).also {
+            if (it == null) {
+              messageCollector.error { "Unknown generated annotation $generatedAnnotationName" }
+              return
+            }
           }
         }
-      }
     val deferred = mutableListOf<GeneratedAdapter>()
     val moshiTransformer =
-      MoshiIrVisitor(
-        moduleFragment,
-        pluginContext,
-        messageCollector,
-        generatedAnnotation,
-        enableSealed,
-        deferred,
-        debug
-      )
+        MoshiIrVisitor(
+            moduleFragment,
+            pluginContext,
+            messageCollector,
+            generatedAnnotation,
+            enableSealed,
+            deferred,
+            debug)
     moduleFragment.transform(moshiTransformer, null)
     for ((file, adapters) in deferred.groupBy { it.irFile }) {
       for (adapter in adapters) {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
@@ -42,13 +42,13 @@ private val JSON_CLASS_ANNOTATION = FqName("com.squareup.moshi.JsonClass")
 internal data class GeneratedAdapter(val adapterClass: IrDeclaration, val irFile: IrFile)
 
 internal class MoshiIrVisitor(
-  moduleFragment: IrModuleFragment,
-  private val pluginContext: IrPluginContext,
-  private val messageCollector: MessageCollector,
-  private val generatedAnnotation: IrClassSymbol?,
-  private val enableSealed: Boolean,
-  private val deferredAddedClasses: MutableList<GeneratedAdapter>,
-  private val debug: Boolean,
+    moduleFragment: IrModuleFragment,
+    private val pluginContext: IrPluginContext,
+    private val messageCollector: MessageCollector,
+    private val generatedAnnotation: IrClassSymbol?,
+    private val enableSealed: Boolean,
+    private val deferredAddedClasses: MutableList<GeneratedAdapter>,
+    private val debug: Boolean,
 ) : IrElementTransformerVoidWithContext() {
 
   private val moshiSymbols by lazy {
@@ -58,7 +58,7 @@ internal class MoshiIrVisitor(
   private val moshiSealedSymbols by lazy { MoshiSealedSymbols(pluginContext) }
 
   private fun adapterGenerator(
-    originalType: IrClass,
+      originalType: IrClass,
   ): MoshiAdapterGenerator? {
     val type = targetType(originalType, pluginContext, messageCollector) ?: return null
 
@@ -89,13 +89,13 @@ internal class MoshiIrVisitor(
 
     // Sort properties so that those with constructor parameters come first.
     val sortedProperties =
-      properties.values.sortedBy {
-        if (it.hasConstructorParameter) {
-          it.target.parameterIndex
-        } else {
-          Integer.MAX_VALUE
+        properties.values.sortedBy {
+          if (it.hasConstructorParameter) {
+            it.target.parameterIndex
+          } else {
+            Integer.MAX_VALUE
+          }
         }
-      }
 
     return MoshiAdapterGenerator(pluginContext, moshiSymbols, type, sortedProperties)
   }
@@ -113,24 +113,23 @@ internal class MoshiIrVisitor(
         @Suppress("UNCHECKED_CAST")
         val generatorValue = (call.getValueArgument(1) as? IrConst<String>?)?.value.orEmpty()
         val generator =
-          if (generatorValue.isNotBlank()) {
-            if (enableSealed && generatorValue.startsWith("sealed:")) {
-              val typeLabel = generatorValue.removePrefix("sealed:")
-              SealedAdapterGenerator(
-                pluginContext,
-                messageCollector,
-                moshiSymbols,
-                moshiSealedSymbols,
-                declaration,
-                typeLabel
-              )
+            if (generatorValue.isNotBlank()) {
+              if (enableSealed && generatorValue.startsWith("sealed:")) {
+                val typeLabel = generatorValue.removePrefix("sealed:")
+                SealedAdapterGenerator(
+                    pluginContext,
+                    messageCollector,
+                    moshiSymbols,
+                    moshiSealedSymbols,
+                    declaration,
+                    typeLabel)
+              } else {
+                return super.visitClassNew(declaration)
+              }
             } else {
-              return super.visitClassNew(declaration)
+              // Unspecified/null - means it's empty/default.
+              adapterGenerator(declaration)
             }
-          } else {
-            // Unspecified/null - means it's empty/default.
-            adapterGenerator(declaration)
-          }
 
         val adapterGenerator = generator ?: return super.visitClassNew(declaration)
         try {
@@ -141,9 +140,8 @@ internal class MoshiIrVisitor(
           if (debug) {
             val irSrc = adapterClass.adapterClass.dumpSrc()
             messageCollector.report(
-              CompilerMessageSeverity.STRONG_WARNING,
-              "MOSHI: Dumping current IR src for ${adapterClass.adapterClass.fqNameWhenAvailable}\n$irSrc"
-            )
+                CompilerMessageSeverity.STRONG_WARNING,
+                "MOSHI: Dumping current IR src for ${adapterClass.adapterClass.name}\n$irSrc")
           }
           deferredAddedClasses += GeneratedAdapter(adapterClass.adapterClass, declaration.file)
         } catch (e: Exception) {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
@@ -19,9 +19,11 @@ import dev.zacsweers.moshix.ir.compiler.api.MoshiAdapterGenerator
 import dev.zacsweers.moshix.ir.compiler.api.PropertyGenerator
 import dev.zacsweers.moshix.ir.compiler.sealed.MoshiSealedSymbols
 import dev.zacsweers.moshix.ir.compiler.sealed.SealedAdapterGenerator
+import dev.zacsweers.moshix.ir.compiler.util.dumpSrc
 import dev.zacsweers.moshix.ir.compiler.util.error
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -40,12 +42,13 @@ private val JSON_CLASS_ANNOTATION = FqName("com.squareup.moshi.JsonClass")
 internal data class GeneratedAdapter(val adapterClass: IrDeclaration, val irFile: IrFile)
 
 internal class MoshiIrVisitor(
-    moduleFragment: IrModuleFragment,
-    private val pluginContext: IrPluginContext,
-    private val messageCollector: MessageCollector,
-    private val generatedAnnotation: IrClassSymbol?,
-    private val enableSealed: Boolean,
-    private val deferredAddedClasses: MutableList<GeneratedAdapter>
+  moduleFragment: IrModuleFragment,
+  private val pluginContext: IrPluginContext,
+  private val messageCollector: MessageCollector,
+  private val generatedAnnotation: IrClassSymbol?,
+  private val enableSealed: Boolean,
+  private val deferredAddedClasses: MutableList<GeneratedAdapter>,
+  private val debug: Boolean,
 ) : IrElementTransformerVoidWithContext() {
 
   private val moshiSymbols by lazy {
@@ -55,7 +58,7 @@ internal class MoshiIrVisitor(
   private val moshiSealedSymbols by lazy { MoshiSealedSymbols(pluginContext) }
 
   private fun adapterGenerator(
-      originalType: IrClass,
+    originalType: IrClass,
   ): MoshiAdapterGenerator? {
     val type = targetType(originalType, pluginContext, messageCollector) ?: return null
 
@@ -86,13 +89,13 @@ internal class MoshiIrVisitor(
 
     // Sort properties so that those with constructor parameters come first.
     val sortedProperties =
-        properties.values.sortedBy {
-          if (it.hasConstructorParameter) {
-            it.target.parameterIndex
-          } else {
-            Integer.MAX_VALUE
-          }
+      properties.values.sortedBy {
+        if (it.hasConstructorParameter) {
+          it.target.parameterIndex
+        } else {
+          Integer.MAX_VALUE
         }
+      }
 
     return MoshiAdapterGenerator(pluginContext, moshiSymbols, type, sortedProperties)
   }
@@ -110,23 +113,24 @@ internal class MoshiIrVisitor(
         @Suppress("UNCHECKED_CAST")
         val generatorValue = (call.getValueArgument(1) as? IrConst<String>?)?.value.orEmpty()
         val generator =
-            if (generatorValue.isNotBlank()) {
-              if (enableSealed && generatorValue.startsWith("sealed:")) {
-                val typeLabel = generatorValue.removePrefix("sealed:")
-                SealedAdapterGenerator(
-                    pluginContext,
-                    messageCollector,
-                    moshiSymbols,
-                    moshiSealedSymbols,
-                    declaration,
-                    typeLabel)
-              } else {
-                return super.visitClassNew(declaration)
-              }
+          if (generatorValue.isNotBlank()) {
+            if (enableSealed && generatorValue.startsWith("sealed:")) {
+              val typeLabel = generatorValue.removePrefix("sealed:")
+              SealedAdapterGenerator(
+                pluginContext,
+                messageCollector,
+                moshiSymbols,
+                moshiSealedSymbols,
+                declaration,
+                typeLabel
+              )
             } else {
-              // Unspecified/null - means it's empty/default.
-              adapterGenerator(declaration)
+              return super.visitClassNew(declaration)
             }
+          } else {
+            // Unspecified/null - means it's empty/default.
+            adapterGenerator(declaration)
+          }
 
         val adapterGenerator = generator ?: return super.visitClassNew(declaration)
         try {
@@ -134,11 +138,13 @@ internal class MoshiIrVisitor(
           if (generatedAnnotation != null) {
             // TODO add generated annotation
           }
-          // Uncomment for debugging generated code
-          //            println("Dumping current IR src")
-          //          messageCollector.report(
-          //              CompilerMessageSeverity.STRONG_WARNING,
-          // adapterClass.adapterClass.dumpSrc())
+          if (debug) {
+            val irSrc = adapterClass.adapterClass.dumpSrc()
+            messageCollector.report(
+              CompilerMessageSeverity.STRONG_WARNING,
+              "MOSHI: Dumping current IR src for ${adapterClass.adapterClass.fqNameWhenAvailable}\n$irSrc"
+            )
+          }
           deferredAddedClasses += GeneratedAdapter(adapterClass.adapterClass, declaration.file)
         } catch (e: Exception) {
           messageCollector.error(declaration) {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/ClassReference.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/ClassReference.kt
@@ -1,0 +1,118 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import dev.zacsweers.moshix.ir.compiler.proguardgen.ClassReference.Descriptor
+import dev.zacsweers.moshix.ir.compiler.proguardgen.ClassReference.Psi
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+/**
+ * Used to create a common type between [KtClassOrObject] class references and [ClassDescriptor]
+ * references, to streamline parsing.
+ *
+ * @see allSuperTypeClassReferences
+ * @see requireClassReference
+ */
+internal sealed class ClassReference {
+
+  abstract val fqName: FqName
+
+  class Psi internal constructor(val clazz: KtClassOrObject, override val fqName: FqName) :
+      ClassReference()
+
+  class Descriptor internal constructor(val clazz: ClassDescriptor, override val fqName: FqName) :
+      ClassReference()
+
+  override fun toString(): String {
+    return "${this::class.qualifiedName}($fqName)"
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is ClassReference) return false
+
+    if (fqName != other.fqName) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    return fqName.hashCode()
+  }
+}
+
+/**
+ * Attempts to resolve the [fqName] to a [ClassDescriptor] first, then falls back to a
+ * [KtClassOrObject] if the descriptor resolution fails. This will happen if the code being parsed
+ * was generated as part of the compilation round for this module.
+ */
+internal fun ModuleDescriptor.classReferenceOrNull(fqName: FqName): ClassReference? {
+  return fqName.classDescriptorOrNull(this)?.toClassReference()
+      ?: getKtClassOrObjectOrNull(fqName)?.toClassReference()
+}
+
+internal fun ClassDescriptor.toClassReference(): Descriptor {
+  return Descriptor(this, fqNameSafe)
+}
+
+internal fun KtClassOrObject.toClassReference(): Psi {
+  return Psi(this, requireFqName())
+}
+
+internal fun ModuleDescriptor.requireClassReference(fqName: FqName): ClassReference {
+  return classReferenceOrNull(fqName)
+      ?: throw MoshiCompilationException("Couldn't resolve ClassReference for $fqName")
+}
+
+/**
+ * This will return all super types as [ClassReference], whether they're parsed as [KtClassOrObject]
+ * or [ClassDescriptor]. This will include generated code, assuming it has already been generated.
+ * The returned sequence will be distinct by FqName, and Psi types are preferred over Descriptors.
+ *
+ * The first elements in the returned sequence represent the direct superclass to the receiver. The
+ * last elements represent the types which are furthest up-stream.
+ *
+ * @param includeSelf If true, the receiver class is the first element of the sequence
+ */
+internal fun ClassReference.allSuperTypeClassReferences(
+    module: ModuleDescriptor,
+    includeSelf: Boolean = false
+): Sequence<ClassReference> {
+  return generateSequence(sequenceOf(this)) { superTypes ->
+    superTypes.map { classRef -> classRef.directSuperClassReferences(module) }.flatten().takeIf {
+      it.firstOrNull() != null
+    }
+  }
+      .drop(if (includeSelf) 0 else 1)
+      .flatten()
+      .distinctBy { it.fqName }
+}
+
+internal fun ClassReference.directSuperClassReferences(
+    module: ModuleDescriptor
+): Sequence<ClassReference> {
+  return when (this) {
+    is Descriptor ->
+        clazz.directSuperClassAndInterfaces().asSequence().map {
+          module.requireClassReference(it.fqNameSafe)
+        }
+    is Psi ->
+        clazz.superTypeListEntries.asSequence().map { it.requireFqName(module) }.map {
+          module.requireClassReference(it)
+        }
+  }
+}
+
+/**
+ * @param parameterName The name of the parameter to be found, not including any variance modifiers.
+ * @return The 0-based index of a declared generic type.
+ */
+internal fun ClassReference.indexOfTypeParameter(parameterName: String): Int {
+  return when (this) {
+    is Descriptor ->
+        clazz.declaredTypeParameters.indexOfFirst { it.name.asString() == parameterName }
+    is Psi -> clazz.typeParameters.indexOfFirst { it.identifyingElement?.text == parameterName }
+  }
+}

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/CompilerUtils.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/CompilerUtils.kt
@@ -63,7 +63,7 @@ internal fun ClassDescriptor.annotation(
  * this class. This is different from [getAllSuperClassifiers] in that the latter returns the entire
  * hierarchy.
  */
-public fun ClassDescriptor.directSuperClassAndInterfaces(): List<ClassDescriptor> {
+internal fun ClassDescriptor.directSuperClassAndInterfaces(): List<ClassDescriptor> {
   return listOfNotNull(getSuperClassNotAny()).plus(getSuperInterfaces())
 }
 

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/CompilerUtils.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/CompilerUtils.kt
@@ -1,0 +1,152 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.platform.has
+import org.jetbrains.kotlin.platform.jvm.JvmPlatform
+import org.jetbrains.kotlin.resolve.constants.ConstantValue
+import org.jetbrains.kotlin.resolve.constants.KClassValue
+import org.jetbrains.kotlin.resolve.constants.KClassValue.Value.NormalClass
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+import org.jetbrains.kotlin.resolve.descriptorUtil.module
+import org.jetbrains.kotlin.types.ErrorType
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.TypeUtils
+import org.jetbrains.kotlin.types.typeUtil.supertypes
+
+internal fun ClassDescriptor.annotationOrNull(
+    annotationFqName: FqName,
+    scope: FqName? = null
+): AnnotationDescriptor? {
+  // Must be JVM, we don't support anything else.
+  if (!module.platform.has<JvmPlatform>()) return null
+  val annotationDescriptor =
+      try {
+        annotations.findAnnotation(annotationFqName)
+      } catch (e: IllegalStateException) {
+        // In some scenarios this exception is thrown. Throw a new exception with a better
+        // explanation.
+        // Caused by: java.lang.IllegalStateException: Should not be called!
+        // at org.jetbrains.kotlin.types.ErrorUtils$1.getPackage(ErrorUtils.java:95)
+        throw MoshiCompilationException(
+            this,
+            message =
+                "It seems like you tried to contribute an inner class to its outer class. This " +
+                    "is not supported and results in a compiler error.",
+            cause = e)
+      }
+  return if (scope == null || annotationDescriptor == null) {
+    annotationDescriptor
+  } else {
+    annotationDescriptor.takeIf { scope == it.scope(module).fqNameSafe }
+  }
+}
+
+internal fun ClassDescriptor.annotation(
+    annotationFqName: FqName,
+    scope: FqName? = null
+): AnnotationDescriptor =
+    requireNotNull(annotationOrNull(annotationFqName, scope)) {
+      "Couldn't find $annotationFqName with scope $scope for $fqNameSafe."
+    }
+
+/**
+ * Returns only the super class (excluding [Any]) and implemented interfaces declared directly by
+ * this class. This is different from [getAllSuperClassifiers] in that the latter returns the entire
+ * hierarchy.
+ */
+public fun ClassDescriptor.directSuperClassAndInterfaces(): List<ClassDescriptor> {
+  return listOfNotNull(getSuperClassNotAny()).plus(getSuperInterfaces())
+}
+
+// When the Kotlin type is of the form: KClass<OurType>.
+internal fun KotlinType.argumentType(): KotlinType = arguments.first().type
+
+internal fun KotlinType.classDescriptorOrNull(): ClassDescriptor? {
+  return TypeUtils.getClassDescriptor(this)
+}
+
+internal fun KotlinType.requireClassDescriptor(): ClassDescriptor {
+  return classDescriptorOrNull()
+      ?: throw MoshiCompilationException("Unable to resolve type for ${this.asTypeName()}")
+}
+
+internal fun AnnotationDescriptor.getAnnotationValue(key: String): ConstantValue<*>? =
+    allValueArguments[Name.identifier(key)]
+
+internal fun AnnotationDescriptor.scope(module: ModuleDescriptor): ClassDescriptor {
+  val annotationValue =
+      getAnnotationValue("scope") as? KClassValue
+          ?: throw MoshiCompilationException(
+              annotationDescriptor = this, message = "Couldn't find scope for $fqName.")
+
+  return annotationValue.argumentType(module).requireClassDescriptor()
+}
+
+internal fun ConstantValue<*>.argumentType(module: ModuleDescriptor): KotlinType {
+  val argumentType = getType(module).argumentType()
+  if (argumentType !is ErrorType) return argumentType
+
+  // Handle inner classes explicitly. When resolving the Kotlin type of inner class from
+  // dependencies the compiler might fail. It tries to load my.package.Class$Inner and fails
+  // whereas is should load my.package.Class.Inner.
+  val normalClass = this.value
+  if (normalClass !is NormalClass) return argumentType
+
+  val classId = normalClass.value.classId
+
+  return module.findClassAcrossModuleDependencies(
+          classId =
+              ClassId(
+                  classId.packageFqName,
+                  FqName(classId.relativeClassName.asString().replace('$', '.')),
+                  false))
+      ?.defaultType
+      ?: throw MoshiCompilationException(
+          "Couldn't resolve class across module dependencies for class ID: $classId")
+}
+
+internal fun List<KotlinType>.getAllSuperTypes(): Sequence<FqName> =
+    generateSequence(this) { kotlinTypes ->
+      kotlinTypes.ifEmpty { null }?.flatMap { it.supertypes() }
+    }
+        .flatMap { it.asSequence() }
+        .map { it.requireClassDescriptor().fqNameSafe }
+
+/**
+ * This function should only be used for package names. If the FqName is the root (no package at
+ * all), then this function returns an empty string whereas `toString()` would return "<root>". For
+ * a more convenient string concatenation the returned result can be prefixed and suffixed with an
+ * additional dot. The root package never will use a prefix or suffix.
+ */
+internal fun FqName.safePackageString(
+    dotPrefix: Boolean = false,
+    dotSuffix: Boolean = true
+): String =
+    if (isRoot) {
+      ""
+    } else {
+      val prefix = if (dotPrefix) "." else ""
+      val suffix = if (dotSuffix) "." else ""
+      "$prefix$this$suffix"
+    }
+
+internal fun FqName.classIdBestGuess(): ClassId {
+  val segments = pathSegments().map { it.asString() }
+  val classNameIndex = segments.indexOfFirst { it[0].isUpperCase() }
+  if (classNameIndex < 0) {
+    return ClassId.topLevel(this)
+  }
+
+  val packageFqName = FqName.fromSegments(segments.subList(0, classNameIndex))
+  val relativeClassName = FqName.fromSegments(segments.subList(classNameIndex, segments.size))
+  return ClassId(packageFqName, relativeClassName, false)
+}

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/FqName.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/FqName.kt
@@ -1,0 +1,4 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+internal val jvmSuppressWildcardsFqName = JvmSuppressWildcards::class.fqName
+internal val publishedApiFqName = PublishedApi::class.fqName

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/KotlinPoetUtils.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/KotlinPoetUtils.kt
@@ -1,0 +1,84 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.WildcardTypeName
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.PackageFragmentDescriptor
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+import org.jetbrains.kotlin.resolve.descriptorUtil.parents
+import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.Variance.INVARIANT
+import org.jetbrains.kotlin.types.Variance.IN_VARIANCE
+import org.jetbrains.kotlin.types.Variance.OUT_VARIANCE
+import org.jetbrains.kotlin.types.typeUtil.isTypeParameter
+
+internal fun KtClassOrObject.asClassName(): ClassName =
+    ClassName(
+        packageName =
+            containingKtFile.packageFqName.safePackageString(dotPrefix = false, dotSuffix = false),
+        simpleNames =
+            parentsWithSelf
+                .filterIsInstance<KtClassOrObject>()
+                .map { it.nameAsSafeName.asString() }
+                .toList()
+                .reversed())
+
+internal fun ClassDescriptor.asClassName(): ClassName =
+    ClassName(
+        packageName =
+            parents
+                .filterIsInstance<PackageFragmentDescriptor>()
+                .first()
+                .fqName
+                .safePackageString(dotSuffix = false),
+        simpleNames =
+            parentsWithSelf
+                .filterIsInstance<ClassDescriptor>()
+                .map { it.name.asString() }
+                .toList()
+                .reversed())
+
+internal fun KotlinType.asTypeName(): TypeName {
+  return asTypeNameOrNull { true }!!
+}
+
+/**
+ * @param rawTypeFilter an optional raw type filter to allow for
+ * ```
+ *                      short-circuiting this before attempting to
+ *                      resolve type arguments.
+ * ```
+ */
+internal fun KotlinType.asTypeNameOrNull(
+    rawTypeFilter: (ClassName) -> Boolean = { true }
+): TypeName? {
+  if (isTypeParameter()) return TypeVariableName(toString())
+
+  val className = requireClassDescriptor().asClassName()
+  if (!rawTypeFilter(className)) {
+    return null
+  }
+  if (arguments.isEmpty()) return className.copy(nullable = isMarkedNullable)
+
+  val argumentTypeNames =
+      arguments.map { typeProjection ->
+        if (typeProjection.isStarProjection) {
+          STAR
+        } else {
+          val typeName = typeProjection.type.asTypeName()
+          when (typeProjection.projectionKind) {
+            INVARIANT -> typeName
+            OUT_VARIANCE -> WildcardTypeName.producerOf(typeName)
+            IN_VARIANCE -> WildcardTypeName.consumerOf(typeName)
+          }
+        }
+      }
+
+  return className.parameterizedBy(argumentTypeNames).copy(nullable = isMarkedNullable)
+}

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiCompilationException.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiCompilationException.kt
@@ -1,0 +1,87 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import org.jetbrains.kotlin.codegen.CompilationException
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.symbols.IrSymbol
+import org.jetbrains.kotlin.ir.util.render
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.resolve.source.KotlinSourceElement
+import org.jetbrains.kotlin.resolve.source.getPsi
+import org.jetbrains.kotlin.util.getExceptionMessage
+
+/**
+ * `AnvilCompilationException` is thrown when Anvil specific code can't be processed or an error
+ * occurs while generating code.
+ */
+public class MoshiCompilationException(
+    message: String,
+    cause: Throwable? = null,
+    element: PsiElement? = null
+) : CompilationException(message, cause, element) {
+  public companion object {
+    public operator fun invoke(
+        annotationDescriptor: AnnotationDescriptor,
+        message: String,
+        cause: Throwable? = null
+    ): MoshiCompilationException {
+      return MoshiCompilationException(
+          message = message, cause = cause, element = annotationDescriptor.identifier)
+    }
+
+    public operator fun invoke(
+        classDescriptor: ClassDescriptor,
+        message: String,
+        cause: Throwable? = null
+    ): MoshiCompilationException {
+      return MoshiCompilationException(
+          message = message, cause = cause, element = classDescriptor.identifier)
+    }
+
+    public operator fun invoke(
+        element: IrElement? = null,
+        message: String,
+        cause: Throwable? = null
+    ): MoshiCompilationException {
+      return MoshiCompilationException(
+              message =
+                  getExceptionMessage(
+                      subsystemName = "Anvil",
+                      message = message,
+                      cause = cause,
+                      location = element?.render()),
+              cause = cause,
+              element = element?.psi)
+          .apply {
+            if (element != null) {
+              withAttachment("element.kt", element.render())
+            }
+          }
+    }
+
+    public operator fun invoke(
+        element: IrSymbol? = null,
+        message: String,
+        cause: Throwable? = null,
+    ): MoshiCompilationException {
+      return MoshiCompilationException(message = message, cause = cause, element = element?.owner)
+    }
+  }
+}
+
+private val ClassDescriptor.identifier: PsiElement?
+  get() = (findPsi() as? PsiNameIdentifierOwner)?.identifyingElement
+
+private val AnnotationDescriptor.identifier: PsiElement?
+  get() = (source as? KotlinSourceElement)?.psi
+
+private val IrElement.psi: PsiElement?
+  get() =
+      when (this) {
+        is IrClass -> (this.source.getPsi() as? PsiNameIdentifierOwner)?.identifyingElement
+        else -> null
+      }

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiCompilationException.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiCompilationException.kt
@@ -18,13 +18,13 @@ import org.jetbrains.kotlin.util.getExceptionMessage
  * `AnvilCompilationException` is thrown when Anvil specific code can't be processed or an error
  * occurs while generating code.
  */
-public class MoshiCompilationException(
+internal class MoshiCompilationException(
     message: String,
     cause: Throwable? = null,
     element: PsiElement? = null
 ) : CompilationException(message, cause, element) {
-  public companion object {
-    public operator fun invoke(
+  companion object {
+    operator fun invoke(
         annotationDescriptor: AnnotationDescriptor,
         message: String,
         cause: Throwable? = null
@@ -33,7 +33,7 @@ public class MoshiCompilationException(
           message = message, cause = cause, element = annotationDescriptor.identifier)
     }
 
-    public operator fun invoke(
+    operator fun invoke(
         classDescriptor: ClassDescriptor,
         message: String,
         cause: Throwable? = null
@@ -42,7 +42,7 @@ public class MoshiCompilationException(
           message = message, cause = cause, element = classDescriptor.identifier)
     }
 
-    public operator fun invoke(
+    operator fun invoke(
         element: IrElement? = null,
         message: String,
         cause: Throwable? = null
@@ -63,7 +63,7 @@ public class MoshiCompilationException(
           }
     }
 
-    public operator fun invoke(
+    operator fun invoke(
         element: IrSymbol? = null,
         message: String,
         cause: Throwable? = null,

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiModuleDescriptor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/MoshiModuleDescriptor.kt
@@ -1,0 +1,36 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+internal interface MoshiModuleDescriptor : ModuleDescriptor {
+  fun resolveClassIdOrNull(classId: ClassId): FqName?
+  fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject?
+
+  companion object {
+    operator fun invoke(delegate: ModuleDescriptor): ModuleDescriptor =
+        RealMoshiModuleDescriptor(delegate)
+  }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun ModuleDescriptor.asAnvilModuleDescriptor(): MoshiModuleDescriptor =
+    this as MoshiModuleDescriptor
+
+internal fun ModuleDescriptor.resolveFqNameOrNull(fqName: FqName): FqName? =
+    asAnvilModuleDescriptor().resolveClassIdOrNull(fqName.classIdBestGuess())
+
+internal fun ModuleDescriptor.getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject? =
+    asAnvilModuleDescriptor().getKtClassOrObjectOrNull(fqName)
+
+internal fun ModuleDescriptor.canResolveFqName(fqName: FqName): Boolean =
+    resolveFqNameOrNull(fqName) != null
+
+internal fun ModuleDescriptor.resolveFqNameOrNull(packageName: FqName, className: String): FqName? =
+    asAnvilModuleDescriptor().resolveClassIdOrNull(ClassId(packageName, Name.identifier(className)))
+
+internal fun ModuleDescriptor.canResolveFqName(packageName: FqName, className: String): Boolean =
+    resolveFqNameOrNull(packageName, className) != null

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/ProguardRuleGenerationExtension.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/ProguardRuleGenerationExtension.kt
@@ -1,0 +1,150 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.codegen.api.InternalMoshiCodegenApi
+import com.squareup.moshi.kotlin.codegen.api.ProguardConfig
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.com.intellij.openapi.extensions.ExtensionPoint
+import org.jetbrains.kotlin.com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.psi.PsiTreeChangeAdapter
+import org.jetbrains.kotlin.com.intellij.psi.PsiTreeChangeListener
+import org.jetbrains.kotlin.container.ComponentProvider
+import org.jetbrains.kotlin.context.ProjectContext
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+
+private val MOSHI_REFLECTIVE_NAME = Moshi::class.asClassName().reflectionName()
+private val TYPE_ARRAY_REFLECTIVE_NAME =
+    "${java.lang.reflect.Type::class.asClassName().reflectionName()}[]"
+
+internal class ProguardRuleGenerationExtension(
+    private val messageCollector: MessageCollector,
+    private val resourcesDir: File,
+    private val enableSealed: Boolean,
+    private val debug: Boolean
+) : AnalysisHandlerExtension {
+
+  private var initialized = false
+  private lateinit var generator: ProguardRuleGenerator
+
+  @OptIn(InternalMoshiCodegenApi::class)
+  override fun doAnalysis(
+      project: Project,
+      module: ModuleDescriptor,
+      projectContext: ProjectContext,
+      files: Collection<KtFile>,
+      bindingTrace: BindingTrace,
+      componentProvider: ComponentProvider
+  ): AnalysisResult? {
+    val moshiModule = MoshiModuleDescriptor(module)
+
+    resourcesDir.listFiles()?.forEach {
+      check(it.deleteRecursively()) { "Could not clean file: $it" }
+    }
+
+    val psiManager = PsiManager.getInstance(project)
+    if (!initialized) {
+      // Dummy extension point; Required by dropPsiCaches().
+      project.extensionArea.registerExtensionPoint(
+          PsiTreeChangeListener.EP.name,
+          PsiTreeChangeAdapter::class.java.canonicalName,
+          ExtensionPoint.Kind.INTERFACE)
+      generator = ProguardRuleGenerator(resourcesDir)
+      initialized = true
+    } else {
+      psiManager.dropPsiCaches()
+    }
+
+    files.flatMap(KtFile::classesAndInnerClasses).forEach { clazz ->
+      val jsonClassAnnotation =
+          clazz.findAnnotation(JsonClass::class.fqName, moshiModule) ?: return@forEach
+      if (jsonClassAnnotation.findAnnotationArgument<Boolean>("generateAdapter", 0) == false) {
+        return@forEach
+      }
+      val generatorKey = jsonClassAnnotation.findAnnotationArgument<String>("generator", 1) ?: ""
+      if (generatorKey.isEmpty() || (enableSealed && generatorKey.startsWith("sealed:"))) {
+        val targetType = clazz.asClassName()
+        val hasGenerics = !clazz.typeParameterList?.parameters.isNullOrEmpty()
+        val adapterName = "${targetType.simpleNames.joinToString(separator = "_")}JsonAdapter"
+        val adapterConstructorParams =
+            when (hasGenerics) {
+              false -> listOf(MOSHI_REFLECTIVE_NAME)
+              true -> listOf(MOSHI_REFLECTIVE_NAME, TYPE_ARRAY_REFLECTIVE_NAME)
+            }
+        val config =
+            ProguardConfig(
+                targetClass = targetType,
+                adapterName = adapterName,
+                adapterConstructorParams = adapterConstructorParams,
+                // Not actually true but in our case we don't need the generated rules for htis
+                targetConstructorHasDefaults = false,
+                targetConstructorParams = emptyList())
+        val fileName = "${targetType.canonicalName}.pro"
+        if (debug) {
+          messageCollector.report(
+              CompilerMessageSeverity.WARNING, "MOSHI: Writing rules for $fileName: $config")
+        }
+        generator
+            .createNewFile(config.outputFilePathWithoutExtension(fileName))
+            .bufferedWriter()
+            .use(config::writeTo)
+      }
+    }
+
+    generator.closeFiles()
+
+    return null
+  }
+}
+
+private class ProguardRuleGenerator(resourcesDir: File) {
+  private val typeRoot = resourcesDir.path
+  private val fileMap = mutableMapOf<String, File>()
+  private val fileOutputStreamMap = mutableMapOf<String, FileOutputStream>()
+  private val separator = File.separator
+
+  // This function will also clear `fileOutputStreamMap` which will change the result of
+  // `generatedFile`
+  fun closeFiles() {
+    fileOutputStreamMap.values.forEach(FileOutputStream::close)
+    fileOutputStreamMap.clear()
+  }
+
+  fun createNewFile(fileName: String): OutputStream {
+    val path = "$typeRoot$separator$fileName".replace("/", separator)
+    if (fileOutputStreamMap[path] == null) {
+      if (fileMap[path] == null) {
+        val file = File(path)
+        val parentFile = file.parentFile
+        if (!parentFile.exists() && !parentFile.mkdirs()) {
+          throw IllegalStateException("failed to make parent directories.")
+        }
+        file.writeText("")
+        fileMap[path] = file
+      }
+      fileOutputStreamMap[path] = fileMap.getValue(path).outputStream()
+    }
+    return fileOutputStreamMap.getValue(path)
+  }
+}
+
+private fun KtFile.classesAndInnerClasses(): List<KtClassOrObject> {
+  val children = findChildrenByClass(KtClassOrObject::class.java)
+
+  return generateSequence(children.toList()) { list ->
+        list.flatMap { it.declarations.filterIsInstance<KtClassOrObject>() }.ifEmpty { null }
+      }
+      .flatten()
+      .toList()
+}

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/PsiUtils.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/PsiUtils.kt
@@ -1,0 +1,477 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import dev.zacsweers.moshix.ir.compiler.proguardgen.ClassReference.Psi
+import kotlin.reflect.KClass
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.KotlinLookupLocation
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotated
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtPureElement
+import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentName
+import org.jetbrains.kotlin.psi.psiUtil.containingClass
+import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
+import org.jetbrains.kotlin.psi.psiUtil.parents
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+
+private val kotlinAnnotations = listOf(jvmSuppressWildcardsFqName, publishedApiFqName)
+
+/** Returns the computed [FqName] representation of this [KClass]. */
+public val KClass<*>.fqName: FqName
+  get() = FqName(java.canonicalName)
+
+internal fun KtNamedDeclaration.requireFqName(): FqName =
+    requireNotNull(fqName) { "fqName was null for $this, $nameAsSafeName" }
+
+internal fun KtAnnotated.findAnnotation(
+    fqName: FqName,
+    module: ModuleDescriptor
+): KtAnnotationEntry? {
+  val annotationEntries = annotationEntries
+  if (annotationEntries.isEmpty()) return null
+
+  // Look first if it's a Kotlin annotation. These annotations are usually not imported and the
+  // remaining checks would fail.
+  if (fqName in kotlinAnnotations) {
+    annotationEntries
+        .firstOrNull { annotation ->
+          val text = annotation.text
+          text.startsWith("@${fqName.shortName()}") || text.startsWith("@$fqName")
+        }
+        ?.let {
+          return it
+        }
+  }
+
+  // Check if the fully qualified name is used, e.g. `@dagger.Module`.
+  val annotationEntry =
+      annotationEntries.firstOrNull { it.text.startsWith("@${fqName.asString()}") }
+  if (annotationEntry != null) return annotationEntry
+
+  // Check if the simple name is used, e.g. `@Module`.
+  val annotationEntryShort =
+      annotationEntries.firstOrNull { it.shortName == fqName.shortName() } ?: return null
+
+  val importPaths = containingKtFile.importDirectives.mapNotNull { it.importPath }
+
+  // If the simple name is used, check that the annotation is imported.
+  val hasImport = importPaths.any { it.fqName == fqName }
+  if (hasImport) return annotationEntryShort
+
+  // Look for star imports and make a guess.
+  val hasStarImport =
+      importPaths.filter { it.isAllUnder }.any {
+        fqName.asString().startsWith(it.fqName.asString())
+      }
+  if (hasStarImport) return annotationEntryShort
+
+  // At this point we know that the class is annotated with an annotation that has the same simple
+  // name as fqName. We couldn't find any imports, so the annotation is likely part of the same
+  // package or Kotlin namespace. Leverage our existing utility function and to find the FqName
+  // and then compare the result.
+  val fqNameOfShort = annotationEntryShort.fqNameOrNull(module)
+  if (fqName == fqNameOfShort) {
+    return annotationEntryShort
+  }
+
+  return null
+}
+
+/**
+ * Finds the argument in the given annotation. [name] refers to the parameter name in the annotation
+ * and [index] to the position of the argument, e.g. if you look for the scope in
+ * `@ContributesBinding(Int::class, boundType = Unit::class)`, then [name] would be "scope" and the
+ * index 0. If you look for the bound type, then [name] would be "boundType" and the index 1.
+ */
+internal inline fun <reified T> KtAnnotationEntry.findAnnotationArgument(
+    name: String,
+    index: Int
+): T? {
+  val annotationValues = valueArguments.asSequence().filterIsInstance<KtValueArgument>()
+
+  // First check if the is any named parameter. Named parameters allow a different order of
+  // arguments.
+  annotationValues
+      .firstNotNullOfOrNull { valueArgument ->
+        val children = valueArgument.children
+        if (children.size == 2 &&
+            children[0] is KtValueArgumentName &&
+            (children[0] as KtValueArgumentName).asName.asString() == name &&
+            children[1] is T) {
+          children[1] as T
+        } else {
+          null
+        }
+      }
+      ?.let {
+        return it
+      }
+
+  // If there is no named argument, then take the first argument, which must be a class literal
+  // expression, e.g. @ContributesTo(Unit::class)
+  return annotationValues.elementAtOrNull(index)?.let { valueArgument ->
+    valueArgument.children.firstOrNull() as? T
+  }
+}
+
+internal fun PsiElement.fqNameOrNull(module: ModuleDescriptor): FqName? {
+  // Usually it's the opposite way, the require*() method calls the nullable method. But in this
+  // case we'd like to preserve the better error messages in case something goes wrong.
+  return try {
+    requireFqName(module)
+  } catch (e: MoshiCompilationException) {
+    null
+  }
+}
+
+internal fun PsiElement.requireFqName(module: ModuleDescriptor): FqName {
+  val containingKtFile = parentsWithSelf.filterIsInstance<KtPureElement>().first().containingKtFile
+
+  fun failTypeHandling(): Nothing =
+      throw MoshiCompilationException("Don't know how to handle Psi element: $text", element = this)
+
+  val classReference =
+      when (this) {
+        // If a fully qualified name is used, then we're done and don't need to do anything further.
+        // An inner class reference like Abc.Inner is also considered a KtDotQualifiedExpression in
+        // some cases.
+        is KtDotQualifiedExpression -> {
+          module.resolveFqNameOrNull(FqName(text))?.let {
+            return it
+          }
+              ?: text
+        }
+        is KtNameReferenceExpression -> getReferencedName()
+        is KtUserType -> {
+          val isGenericType = children.any { it is KtTypeArgumentList }
+          if (isGenericType) {
+            // For an expression like Lazy<Abc> the qualifier will be null. If the qualifier exists,
+            // then it may refer to the package and the referencedName refers to the class name,
+            // e.g.
+            // a KtUserType "abc.def.GenericType<String>" has three children: a qualifier "abc.def",
+            // the referencedName "GenericType" and the KtTypeArgumentList.
+            val qualifierText = qualifier?.text
+            val className = referencedName
+
+            if (qualifierText != null) {
+
+              // The generic might be fully qualified. Try to resolve it and return early.
+              module.resolveFqNameOrNull(FqName("$qualifierText.$className"))?.let {
+                return it
+              }
+
+              // If the name isn't fully qualified, then it's something like "Outer.Inner".
+              // We can't use `text` here because that includes the type parameter(s).
+              "$qualifierText.$className"
+            } else {
+              className ?: failTypeHandling()
+            }
+          } else {
+            val text = text
+
+            // Sometimes a KtUserType is a fully qualified name. Give it a try and return early.
+            if (text.contains(".") && text[0].isLowerCase()) {
+              module.resolveFqNameOrNull(FqName(text))?.let {
+                return it
+              }
+            }
+
+            // We can't use referencedName here. For inner classes like "Outer.Inner" it would only
+            // return "Inner", whereas text returns "Outer.Inner", what we expect.
+            text
+          }
+        }
+        is KtTypeReference -> {
+          val children = children
+          if (children.size == 1) {
+            try {
+              // Could be a KtNullableType or KtUserType.
+              return children[0].requireFqName(module)
+            } catch (e: MoshiCompilationException) {
+              // Fallback to the text representation.
+              text
+            }
+          } else {
+            text
+          }
+        }
+        is KtNullableType -> return innerType?.requireFqName(module) ?: failTypeHandling()
+        is KtAnnotationEntry -> return typeReference?.requireFqName(module) ?: failTypeHandling()
+        is KtClassLiteralExpression -> {
+          // Returns "Abc" for "Abc::class".
+          val element =
+              children.singleOrNull()
+                  ?: throw MoshiCompilationException(
+                      "Expected a single child, but there were ${children.size} instead: $text",
+                      element = this)
+          return element.requireFqName(module)
+        }
+        is KtSuperTypeListEntry -> return typeReference?.requireFqName(module) ?: failTypeHandling()
+        else -> failTypeHandling()
+      }
+
+  // E.g. OuterClass.InnerClass
+  val classReferenceOuter = classReference.substringBefore(".")
+
+  val importPaths = containingKtFile.importDirectives.mapNotNull { it.importPath }
+
+  // First look in the imports for the reference name. If the class is imported, then we know the
+  // fully qualified name.
+  importPaths
+      .filter { it.alias == null && it.fqName.shortName().asString() == classReference }
+      .also { matchingImportPaths ->
+        when {
+          matchingImportPaths.size == 1 -> return matchingImportPaths[0].fqName
+          matchingImportPaths.size > 1 ->
+              return matchingImportPaths
+                  .first { importPath -> module.canResolveFqName(importPath.fqName) }
+                  .fqName
+        }
+      }
+
+  importPaths
+      .filter { it.alias == null && it.fqName.shortName().asString() == classReferenceOuter }
+      .also { matchingImportPaths ->
+        when {
+          matchingImportPaths.size == 1 ->
+              return FqName("${matchingImportPaths[0].fqName.parent()}.$classReference")
+          matchingImportPaths.size > 1 ->
+              return matchingImportPaths
+                  .first { importPath ->
+                    module.canResolveFqName(importPath.fqName, classReference)
+                  }
+                  .fqName
+        }
+      }
+
+  containingKtFile
+      .importDirectives
+      .asSequence()
+      .filter { it.isAllUnder }
+      .mapNotNull {
+        // This fqName is everything in front of the star, e.g. for "import java.io.*" it
+        // returns "java.io".
+        it.importPath?.fqName
+      }
+      .forEach { importFqName ->
+        if (importFqName.asString() == "java.util") {
+          // If there's a star import for java.util.* and the import is a Collection type, then
+          // the Kotlin compiler overrides these with Kotlin types.
+          module.resolveFqNameOrNull(FqName("kotlin.collections.$classReference"))?.let {
+            return it
+          }
+        }
+
+        module.resolveFqNameOrNull(importFqName, classReference)?.let {
+          return it
+        }
+      }
+
+  // If there is no import, then try to resolve the class with the same package as this file.
+  module.resolveFqNameOrNull(containingKtFile.packageFqName, classReference)?.let {
+    return it
+  }
+
+  // If this doesn't work, then maybe a class from the Kotlin package is used.
+  module.resolveFqNameOrNull(FqName("kotlin.$classReference"))?.let {
+    return it
+  }
+
+  // If this doesn't work, then maybe a class from the Kotlin collection package is used.
+  module.resolveFqNameOrNull(FqName("kotlin.collections.$classReference"))?.let {
+    return it
+  }
+
+  // If this doesn't work, then maybe a class from the Kotlin jvm package is used.
+  module.resolveFqNameOrNull(FqName("kotlin.jvm.$classReference"))?.let {
+    return it
+  }
+
+  // Or java.lang.
+  module.resolveFqNameOrNull(FqName("java.lang.$classReference"))?.let {
+    return it
+  }
+
+  findFqNameInSuperTypes(module, classReference)?.let {
+    return it
+  }
+
+  // Check if it's a named import.
+  containingKtFile.importDirectives
+      .firstOrNull { classReference == it.importPath?.importedName?.asString() }
+      ?.importedFqName
+      ?.let {
+        return it
+      }
+
+  // Everything else isn't supported.
+  throw MoshiCompilationException(
+      "Couldn't resolve FqName $classReference for Psi element: $text", element = this)
+}
+
+private fun PsiElement.findFqNameInSuperTypes(
+    module: ModuleDescriptor,
+    classReference: String
+): FqName? {
+  fun tryToResolveClassFqName(outerClass: FqName): FqName? =
+      module.resolveFqNameOrNull(FqName("$outerClass.$classReference"))
+
+  return parents
+      .filterIsInstance<KtClassOrObject>()
+      .flatMap { clazz ->
+        tryToResolveClassFqName(clazz.requireFqName())?.let {
+          return@flatMap sequenceOf(it)
+        }
+
+        // At this point we can't work with Psi APIs anymore. We need to resolve the super types
+        // and try to find inner class in them.
+        val descriptor = clazz.requireClassDescriptor(module)
+        listOf(descriptor.defaultType).getAllSuperTypes().mapNotNull { tryToResolveClassFqName(it) }
+      }
+      .firstOrNull()
+}
+
+/**
+ * Safely resolves a PSI [KtTypeReference], when that type reference may be a generic expressed by a
+ * type variable name. This is done by inspecting the class hierarchy to find where the generic type
+ * is declared, then resolving *that* reference.
+ *
+ * For instance, given:
+ *
+ * ```
+ * interface Factory<T> {
+ *   fun create(): T
+ * }
+ *
+ * interface ServiceFactory : Factory<Service>
+ * ```
+ *
+ * The KtTypeReference `T` will fail to resolve, since it isn't a type. This function will instead
+ * look to the `ServiceFactory` interface, then look at the supertype declaration in order to
+ * determine the type.
+ *
+ * @receiver The class which actually references the type. In the above example, this would be
+ * `ServiceFactory`.
+ */
+internal fun KtClassOrObject.resolveTypeReference(
+    module: ModuleDescriptor,
+    typeReference: KtTypeReference
+): KtTypeReference? {
+
+  // if the element isn't a type variable name like `T`, it can be resolved through imports.
+  typeReference.typeElement?.fqNameOrNull(module)?.let {
+    return typeReference
+  }
+
+  val declaringClass = typeReference.requireContainingClassReference()
+  val parameterName = typeReference.text
+
+  return resolveGenericTypeReference(module, declaringClass, parameterName)
+}
+
+private fun KtClassOrObject.resolveGenericTypeReference(
+    module: ModuleDescriptor,
+    declaringClass: ClassReference,
+    parameterName: String
+): KtTypeReference? {
+  val declaringClassFqName = declaringClass.fqName
+
+  // If the class/interface declaring the generic is the receiver class,
+  // then the generic hasn't been set to a concrete type and can't be resolved.
+  if (requireFqName() == declaringClassFqName) {
+    return null
+  }
+
+  // Used to determine which parameter to look at in a KtTypeArgumentList
+  val indexOfType = declaringClass.indexOfTypeParameter(parameterName)
+
+  // Find where the supertype is actually declared by matching the FqName of the SuperTypeListEntry
+  // to the type which declares the generic we're trying to resolve.
+  // After finding the SuperTypeListEntry, just take the TypeReference from its type argument list
+  val resolvedTypeReference =
+      superTypeListEntryOrNull(module, declaringClassFqName)
+          ?.typeReference
+          ?.typeElement
+          ?.getChildOfType<KtTypeArgumentList>()
+          ?.arguments
+          ?.get(indexOfType)
+          ?.typeReference
+
+  return resolvedTypeReference?.takeIf { it.fqNameOrNull(module) != null }
+      ?: resolvedTypeReference?.let { resolveTypeReference(module, it) }
+}
+
+/**
+ * Find where a super type is extended/implemented by matching the FqName of a SuperTypeListEntry to
+ * the FqName of the target super type.
+ *
+ * For instance, given:
+ *
+ * ```
+ * interface Base<T> {
+ *   fun create(): T
+ * }
+ *
+ * abstract class Middle : Comparable<MyClass>, Provider<Something>, Base<Something>
+ *
+ * class InjectClass : Middle()
+ * ```
+ *
+ * We start at the declaration of `InjectClass`, looking for a super declaration of `Base<___>`.
+ * Since `InjectClass` doesn't declare it, we look through the supers of `Middle` and find it, then
+ * resolve `T` to `Something`.
+ */
+internal fun KtClassOrObject.superTypeListEntryOrNull(
+    module: ModuleDescriptor,
+    superTypeFqName: FqName
+): KtSuperTypeListEntry? {
+  return toClassReference()
+      .allSuperTypeClassReferences(module, includeSelf = true)
+      .filterIsInstance<Psi>()
+      .firstNotNullOfOrNull { classReference ->
+        classReference.clazz.superTypeListEntries.firstOrNull {
+          it.requireFqName(module) == superTypeFqName
+        }
+      }
+}
+
+internal fun KtClassOrObject.requireClassDescriptor(module: ModuleDescriptor): ClassDescriptor {
+  return classDescriptorOrNull(module)
+      ?: throw MoshiCompilationException(
+          "Couldn't resolve class for ${requireFqName()}.", element = this)
+}
+
+internal fun KtClassOrObject.classDescriptorOrNull(module: ModuleDescriptor): ClassDescriptor? {
+  return module.resolveClassByFqName(requireFqName(), KotlinLookupLocation(this))
+}
+
+internal fun FqName.classDescriptorOrNull(module: ModuleDescriptor): ClassDescriptor? {
+  return module.resolveClassByFqName(this, FROM_BACKEND)
+  // In the case of a typealias, we need to look up the original reference instead.
+  ?: module.findTypeAliasAcrossModuleDependencies(classIdBestGuess())?.classDescriptor
+}
+
+internal fun KtTypeReference.containingClassReferenceOrNull(): ClassReference? {
+  return typeElement?.containingClass()?.toClassReference()
+}
+
+internal fun KtTypeReference.requireContainingClassReference(): ClassReference {
+  return containingClassReferenceOrNull()
+      ?: throw MoshiCompilationException("Unable to find a containing class.", element = this)
+}

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/PsiUtils.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/PsiUtils.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 private val kotlinAnnotations = listOf(jvmSuppressWildcardsFqName, publishedApiFqName)
 
 /** Returns the computed [FqName] representation of this [KClass]. */
-public val KClass<*>.fqName: FqName
+internal val KClass<*>.fqName: FqName
   get() = FqName(java.canonicalName)
 
 internal fun KtNamedDeclaration.requireFqName(): FqName =

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/RealMoshiModuleDescriptor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/proguardgen/RealMoshiModuleDescriptor.kt
@@ -1,0 +1,36 @@
+package dev.zacsweers.moshix.ir.compiler.proguardgen
+
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+internal class RealMoshiModuleDescriptor(delegate: ModuleDescriptor) :
+    MoshiModuleDescriptor, ModuleDescriptor by delegate {
+
+  private val classesMap = mutableMapOf<String, List<KtClassOrObject>>()
+  private val allClasses: Sequence<KtClassOrObject>
+    get() = classesMap.values.asSequence().flatMap { it }
+
+  override fun resolveClassIdOrNull(classId: ClassId): FqName? {
+    val fqName = classId.asSingleFqName()
+
+    resolveClassByFqName(fqName, FROM_BACKEND)?.let {
+      return it.fqNameSafe
+    }
+
+    findTypeAliasAcrossModuleDependencies(classId)?.let {
+      return it.fqNameSafe
+    }
+
+    return allClasses.firstOrNull { it.fqName == fqName }?.fqName
+  }
+
+  override fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject? {
+    return allClasses.firstOrNull { it.fqName == fqName }
+  }
+}

--- a/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitorTest.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitorTest.kt
@@ -22,8 +22,10 @@ import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.PluginOption
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.SourceFile.Companion.kotlin
+import java.io.File
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.JvmTarget
+import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -32,6 +34,15 @@ import org.junit.rules.TemporaryFolder
 class MoshiIrVisitorTest {
 
   @Rule @JvmField var temporaryFolder: TemporaryFolder = TemporaryFolder()
+
+  private lateinit var compilationDir: File
+  private lateinit var resourcesDir: File
+
+  @Before
+  fun setup() {
+    compilationDir = temporaryFolder.newFolder("compilationDir")
+    resourcesDir = temporaryFolder.newFolder("resourcesDir")
+  }
 
   @Test
   fun valueClassesCannotHaveDefaultValues() {
@@ -506,6 +517,234 @@ class MoshiIrVisitorTest {
     //    )
   }
 
+  @Test
+  fun `Processor should generate comprehensive proguard rules`() {
+    val compilation =
+        prepareCompilation(
+            kotlin(
+                "source.kt",
+                """
+          package testPackage
+          import com.squareup.moshi.JsonClass
+          import com.squareup.moshi.JsonQualifier
+
+          typealias FirstName = String
+          typealias LastName = String
+
+          @JsonClass(generateAdapter = true)
+          data class Aliases(val firstName: FirstName, val lastName: LastName, val hairColor: String)
+
+          @JsonClass(generateAdapter = true)
+          data class Simple(val firstName: String)
+
+          @JsonClass(generateAdapter = true)
+          data class Generic<T>(val firstName: T, val lastName: String)
+
+          @JsonQualifier
+          annotation class MyQualifier
+
+          @JsonClass(generateAdapter = true)
+          data class UsingQualifiers(val firstName: String, @MyQualifier val lastName: String)
+
+          @JsonClass(generateAdapter = true)
+          data class MixedTypes(val firstName: String, val otherNames: MutableList<String>)
+
+          @JsonClass(generateAdapter = true)
+          data class DefaultParams(val firstName: String = "")
+
+          @JsonClass(generateAdapter = true)
+          data class Complex<T>(val firstName: FirstName = "", @MyQualifier val names: MutableList<String>, val genericProp: T)
+
+          object NestedType {
+            @JsonQualifier
+            annotation class NestedQualifier
+
+            @JsonClass(generateAdapter = true)
+            data class NestedSimple(@NestedQualifier val firstName: String)
+          }
+
+          @JsonClass(generateAdapter = true)
+          class MultipleMasks(
+              val arg0: Long = 0,
+              val arg1: Long = 1,
+              val arg2: Long = 2,
+              val arg3: Long = 3,
+              val arg4: Long = 4,
+              val arg5: Long = 5,
+              val arg6: Long = 6,
+              val arg7: Long = 7,
+              val arg8: Long = 8,
+              val arg9: Long = 9,
+              val arg10: Long = 10,
+              val arg11: Long,
+              val arg12: Long = 12,
+              val arg13: Long = 13,
+              val arg14: Long = 14,
+              val arg15: Long = 15,
+              val arg16: Long = 16,
+              val arg17: Long = 17,
+              val arg18: Long = 18,
+              val arg19: Long = 19,
+              @Suppress("UNUSED_PARAMETER") arg20: Long = 20,
+              val arg21: Long = 21,
+              val arg22: Long = 22,
+              val arg23: Long = 23,
+              val arg24: Long = 24,
+              val arg25: Long = 25,
+              val arg26: Long = 26,
+              val arg27: Long = 27,
+              val arg28: Long = 28,
+              val arg29: Long = 29,
+              val arg30: Long = 30,
+              val arg31: Long = 31,
+              val arg32: Long = 32,
+              val arg33: Long = 33,
+              val arg34: Long = 34,
+              val arg35: Long = 35,
+              val arg36: Long = 36,
+              val arg37: Long = 37,
+              val arg38: Long = 38,
+              @Transient val arg39: Long = 39,
+              val arg40: Long = 40,
+              val arg41: Long = 41,
+              val arg42: Long = 42,
+              val arg43: Long = 43,
+              val arg44: Long = 44,
+              val arg45: Long = 45,
+              val arg46: Long = 46,
+              val arg47: Long = 47,
+              val arg48: Long = 48,
+              val arg49: Long = 49,
+              val arg50: Long = 50,
+              val arg51: Long = 51,
+              val arg52: Long = 52,
+              @Transient val arg53: Long = 53,
+              val arg54: Long = 54,
+              val arg55: Long = 55,
+              val arg56: Long = 56,
+              val arg57: Long = 57,
+              val arg58: Long = 58,
+              val arg59: Long = 59,
+              val arg60: Long = 60,
+              val arg61: Long = 61,
+              val arg62: Long = 62,
+              val arg63: Long = 63,
+              val arg64: Long = 64,
+              val arg65: Long = 65
+          )
+          """))
+    val result = compilation.compile()
+    assertThat(result.exitCode).isEqualTo(OK)
+
+    resourcesDir.walkTopDown().filter { it.extension == "pro" }.forEach { generatedFile ->
+      when (generatedFile.nameWithoutExtension) {
+        "moshi-testPackage.Aliases" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.Aliases
+          -keepnames class testPackage.Aliases
+          -if class testPackage.Aliases
+          -keep class testPackage.AliasesJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi);
+          }
+          """.trimIndent())
+        "moshi-testPackage.Simple" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.Simple
+          -keepnames class testPackage.Simple
+          -if class testPackage.Simple
+          -keep class testPackage.SimpleJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi);
+          }
+          """.trimIndent())
+        "moshi-testPackage.Generic" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.Generic
+          -keepnames class testPackage.Generic
+          -if class testPackage.Generic
+          -keep class testPackage.GenericJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi,java.lang.reflect.Type[]);
+          }
+          """.trimIndent())
+        "moshi-testPackage.UsingQualifiers" -> {
+          assertThat(generatedFile.readText())
+              .contains(
+                  """
+            -if class testPackage.UsingQualifiers
+            -keepnames class testPackage.UsingQualifiers
+            -if class testPackage.UsingQualifiers
+            -keep class testPackage.UsingQualifiersJsonAdapter {
+                public <init>(com.squareup.moshi.Moshi);
+            }
+            """.trimIndent())
+        }
+        "moshi-testPackage.MixedTypes" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.MixedTypes
+          -keepnames class testPackage.MixedTypes
+          -if class testPackage.MixedTypes
+          -keep class testPackage.MixedTypesJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi);
+          }
+          """.trimIndent())
+        "moshi-testPackage.DefaultParams" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.DefaultParams
+          -keepnames class testPackage.DefaultParams
+          -if class testPackage.DefaultParams
+          -keep class testPackage.DefaultParamsJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi);
+          }
+          """.trimIndent())
+        "moshi-testPackage.Complex" -> {
+          assertThat(generatedFile.readText())
+              .contains(
+                  """
+            -if class testPackage.Complex
+            -keepnames class testPackage.Complex
+            -if class testPackage.Complex
+            -keep class testPackage.ComplexJsonAdapter {
+                public <init>(com.squareup.moshi.Moshi,java.lang.reflect.Type[]);
+            }
+            """.trimIndent())
+        }
+        "moshi-testPackage.MultipleMasks" ->
+            assertThat(generatedFile.readText())
+                .contains(
+                    """
+          -if class testPackage.MultipleMasks
+          -keepnames class testPackage.MultipleMasks
+          -if class testPackage.MultipleMasks
+          -keep class testPackage.MultipleMasksJsonAdapter {
+              public <init>(com.squareup.moshi.Moshi);
+          }
+          """.trimIndent())
+        "moshi-testPackage.NestedType.NestedSimple" -> {
+          assertThat(generatedFile.readText())
+              .contains(
+                  """
+            -if class testPackage.NestedType${'$'}NestedSimple
+            -keepnames class testPackage.NestedType${'$'}NestedSimple
+            -if class testPackage.NestedType${'$'}NestedSimple
+            -keep class testPackage.NestedType_NestedSimpleJsonAdapter {
+                public <init>(com.squareup.moshi.Moshi);
+            }
+            """.trimIndent())
+        }
+        else -> error("Unexpected proguard file! ${generatedFile.name}")
+      }
+    }
+  }
+
   private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {
     return prepareCompilation(null, *sourceFiles)
   }
@@ -515,13 +754,16 @@ class MoshiIrVisitorTest {
       vararg sourceFiles: SourceFile
   ): KotlinCompilation {
     return KotlinCompilation().apply {
-      workingDir = temporaryFolder.root
+      workingDir = compilationDir
       compilerPlugins = listOf(MoshiComponentRegistrar())
       val processor = MoshiCommandLineProcessor()
       commandLineProcessors = listOf(processor)
       pluginOptions =
           buildList {
             add(processor.option(KEY_ENABLED, "true"))
+            add(processor.option(KEY_DEBUG, "false")) // Enable when needed for extra debugging
+            add(processor.option(KEY_GENERATE_PROGUARD_RULES, "true"))
+            add(processor.option(KEY_RESOURCES_OUTPUT_DIR, resourcesDir))
             if (generatedAnnotation != null) {
               processor.option(KEY_GENERATED_ANNOTATION, generatedAnnotation)
             }

--- a/moshi-ir/moshi-gradle-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-gradle-plugin/build.gradle.kts
@@ -65,7 +65,10 @@ tasks.named<DokkaTask>("dokkaHtml") {
   dokkaSourceSets.configureEach { skipDeprecated.set(true) }
 }
 
-repositories { mavenCentral() }
+repositories {
+  mavenCentral()
+  google()
+}
 
 spotless {
   format("misc") {
@@ -86,6 +89,7 @@ spotless {
 
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.6.10")
+  compileOnly("com.android.tools.build:gradle:7.0.4")
   compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
   implementation("com.google.auto.service:auto-service-annotations:1.0.1")
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
@@ -21,8 +21,13 @@ import org.gradle.api.provider.Property
 
 abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) {
   val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(true)
+  /** Enables debug logging. Useful mostly for helping report bugs/issues. */
+  val debug: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(false)
   /** Note: this is not currently implemented yet */
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   /** Enables moshi-sealed code gen. Disabled by default. */
   val enableSealed: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /** Enables automatic generation of proguard rules. Enabled by default. */
+  val generateProguardRules: Property<Boolean> =
+      objects.property(Boolean::class.java).convention(true)
 }


### PR DESCRIPTION
This implements generation of proguard rules. Note that these do not do any precondition checks and instead defer them to the IR transformer. This is configurable and also implements a debug option along the way.

Resolves #196, resolves #193