### PR TITLE
Add gradle plugin as implementation not api

### DIFF
--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -64,11 +64,11 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     val sourceSetName = kotlinCompilation.compilationName
 
     // Minimum Moshi version
-    project.dependencies.add("api", "com.squareup.moshi:moshi:1.13.0")
+    project.dependencies.add("implementation", "com.squareup.moshi:moshi:1.13.0")
 
     val enableSealed = extension.enableSealed.get()
     if (enableSealed) {
-      project.dependencies.add("api", "dev.zacsweers.moshix:moshi-sealed-runtime:$VERSION")
+      project.dependencies.add("implementation", "dev.zacsweers.moshix:moshi-sealed-runtime:$VERSION")
     }
 
     if (generateProguardRules) {


### PR DESCRIPTION
Same principle as https://github.com/ZacSweers/redacted-compiler-plugin/pull/77. This just bit us twice.