### PR TITLE
[R8] Keep JsonClass annotations for NestedSealed.Factory

### DIFF
--- a/moshi-sealed/java-sealed-reflect/src/main/resources/META-INF/proguard/moshi-sealed.pro
+++ b/moshi-sealed/java-sealed-reflect/src/main/resources/META-INF/proguard/moshi-sealed.pro
@@ -2,3 +2,7 @@
 -keep interface dev.zacsweers.moshix.sealed.annotations.DefaultNull { *; }
 -keep interface dev.zacsweers.moshix.sealed.annotations.DefaultObject { *; }
 -keep interface dev.zacsweers.moshix.sealed.annotations.TypeLabel { *; }
+
+# Keep JsonClass annotations for NestedSealed.Factory
+-keep @com.squareup.moshi.JsonClass class *
+-keep @com.squareup.moshi.JsonClass interface *


### PR DESCRIPTION
Initial issue: #324. As it turns out, R8 removes the `JsonClass` annotations that `NestedSealed.Factory` needs at runtime to identify sealed classes. The solution was to add a ProGuard rule to keep the `JsonClass` annotations.

Close #324