### PR TITLE
Switch to maintained KCT + support K2 in some places

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ agp = "7.3.1"
 autoService = "1.0.1"
 incap = "0.3"
 gjf = "1.13.0"
-kotlinCompileTesting = "1.4.9"
+kotlinCompileTesting = "0.1.0"
 kotlin = "1.7.20"
 javaRelease = "8"
 jvmTarget = "1.8"
@@ -80,5 +80,5 @@ retrofit-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.re
 # Test libs
 junit = { module = "junit:junit", version = "4.13.2" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
-kotlinCompileTesting = { module = "com.github.tschuchortdev:kotlin-compile-testing", version.ref = "kotlinCompileTesting" }
-kotlinCompileTesting-ksp = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version.ref ="kotlinCompileTesting" }
+kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version.ref = "kotlinCompileTesting" }
+kotlinCompileTesting-ksp = { module = "dev.zacsweers.kctfork:ksp", version.ref ="kotlinCompileTesting" }

--- a/moshi-ir/moshi-compiler-plugin/api/moshi-compiler-plugin.api
+++ b/moshi-ir/moshi-compiler-plugin/api/moshi-compiler-plugin.api
@@ -7,6 +7,7 @@ public final class dev/zacsweers/moshix/ir/compiler/MoshiCommandLineProcessor : 
 
 public final class dev/zacsweers/moshix/ir/compiler/MoshiComponentRegistrar : org/jetbrains/kotlin/compiler/plugin/ComponentRegistrar {
 	public fun <init> ()V
+	public fun getSupportsK2 ()Z
 	public fun registerProjectComponents (Lorg/jetbrains/kotlin/com/intellij/mock/MockProject;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
 }
 

--- a/moshi-ir/moshi-compiler-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-compiler-plugin/build.gradle.kts
@@ -30,6 +30,10 @@ tasks.withType<KotlinCompile>().configureEach {
   }
 }
 
+tasks.withType<Test>().configureEach {
+  systemProperty("moshix.jvmTarget", libs.versions.jvmTarget.get())
+}
+
 dependencies {
   //  compileOnly(kotlin("compiler"))
   compileOnly(libs.kotlin.compilerEmbeddable)


### PR DESCRIPTION
This switches to a maintained version of KCT and enables support for K2 in moshi-ir IFF proguard rule generation is disabled.