### PR TITLE
update kotlinx-metadata-jvm to 0.6.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ incap = { module = "net.ltgt.gradle.incap:incap", version.ref = "incap" }
 incap-processor = { module = "net.ltgt.gradle.incap:incap-processor", version.ref = "incap" }
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.5.0" }
+kotlin-metadata = { module = "org.jetbrains.kotlinx:kotlinx-metadata-jvm", version = "0.6.0" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePlugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/MetadataKotlinJsonAdapterFactory.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/MetadataKotlinJsonAdapterFactory.kt
@@ -37,8 +37,8 @@ import kotlinx.metadata.KmType
 import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.jvm.JvmFieldSignature
 import kotlinx.metadata.jvm.JvmMethodSignature
-import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata
 import kotlinx.metadata.jvm.fieldSignature
 import kotlinx.metadata.jvm.getterSignature
 import kotlinx.metadata.jvm.setterSignature
@@ -376,10 +376,10 @@ public class MetadataKotlinJsonAdapterFactory : JsonAdapter.Factory {
   }
 }
 
-private fun Class<*>.header(): KotlinClassHeader? {
+private fun Class<*>.header(): Metadata? {
   val metadata = getAnnotation(KOTLIN_METADATA) ?: return null
   return with(metadata) {
-    KotlinClassHeader(
+    Metadata(
       kind = kind,
       metadataVersion = metadataVersion,
       data1 = data1,
@@ -391,7 +391,7 @@ private fun Class<*>.header(): KotlinClassHeader? {
   }
 }
 
-private fun KotlinClassHeader.toKmClass(): KmClass? {
+private fun Metadata.toKmClass(): KmClass? {
   val classMetadata = KotlinClassMetadata.read(this)
   if (classMetadata !is KotlinClassMetadata.Class) {
     return null

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -31,8 +31,8 @@ import java.lang.reflect.Type
 import kotlinx.metadata.ClassName
 import kotlinx.metadata.Flag
 import kotlinx.metadata.KmClass
-import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.metadata.jvm.Metadata
 
 /** Classes annotated with this are eligible for this adapter. */
 private val KOTLIN_METADATA = Metadata::class.java
@@ -153,10 +153,10 @@ public class MetadataMoshiSealedJsonAdapterFactory : JsonAdapter.Factory {
   }
 }
 
-private fun Class<*>.header(): KotlinClassHeader? {
+private fun Class<*>.header(): Metadata? {
   val metadata = getAnnotation(KOTLIN_METADATA) ?: return null
   return with(metadata) {
-    KotlinClassHeader(
+    Metadata(
       kind = kind,
       metadataVersion = metadataVersion,
       data1 = data1,
@@ -168,7 +168,7 @@ private fun Class<*>.header(): KotlinClassHeader? {
   }
 }
 
-private fun KotlinClassHeader.toKmClass(): KmClass? {
+private fun Metadata.toKmClass(): KmClass? {
   val classMetadata = KotlinClassMetadata.read(this)
   if (classMetadata !is KotlinClassMetadata.Class) {
     return null


### PR DESCRIPTION
Only replaced the deprecated `KotlinClassHeader` with instantiating `Metadata` directly.