### PR TITLE
Keep names on `@NestedSealed` types

### DIFF
--- a/moshi-sealed/runtime/src/main/resources/META-INF/proguard/moshi-sealed.pro
+++ b/moshi-sealed/runtime/src/main/resources/META-INF/proguard/moshi-sealed.pro
@@ -1,5 +1,9 @@
-# Keep NestedSealed for runtime use
+# Keep NestedSealed for runtime use.
 -keep interface dev.zacsweers.moshix.sealed.annotations.NestedSealed { *; }
+
+# Keep signatures for typed annotated with NestedSealed. This ensures that the annotation, while kept generally above,
+# isn't stripped from the use on the class.
+-keepnames @dev.zacsweers.moshix.sealed.annotations.NestedSealed class **
 
 # Keep generic signatures and annotations at runtime.
 # R8 requires InnerClasses and EnclosingMethod if you keepattributes Signature.


### PR DESCRIPTION
This ensures that the annotations themselves aren't stripped from the class descriptor and thus available at runtime.

Resolves #411