### PR TITLE
remove local development section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Extensions for [Moshi](https://github.com/square/moshi)
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
 
-### Local development
-
-This project requires JDK 20 as a minimum due to tooling compatibility requirements to build against newer JDK
-APIs.
-
 License
 --------
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 
 ### Local development
 
-This project requires JDK 17 as a minimum due to tooling compatibility requirements to build against newer JDK
+This project requires JDK 20 as a minimum due to tooling compatibility requirements to build against newer JDK
 APIs.
 
 License


### PR DESCRIPTION
I recently pulled down MoshiX to do some local testing and had to have JDK 20 installed. I think that's inline with what the library catalog specifies https://github.com/ZacSweers/MoshiX/blob/4cb15346cf62955557bb06d35b05e7817c3185e4/gradle/libs.versions.toml#L20

Sorry in advance if this was an incorrect assumption!