### PR TITLE
kotlinx immutable collections JSON adapters

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ jvmTarget = "11"
 kotlin = "1.9.0"
 kotlinCompileTesting = "0.3.2"
 kotlinpoet = "1.14.2"
+kotlinxCollectionsImmutable = "0.3.5"
 ksp = "1.9.0-1.0.13"
 ktfmt = "0.44"
 moshi = "1.15.0"
@@ -61,6 +62,8 @@ kotlin-gradlePlugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref = "kotlinpoet" }
 kotlinpoet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinpoet" }
+
+kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }

--- a/moshi-adapters-kotlinx-immutable/README.md
+++ b/moshi-adapters-kotlinx-immutable/README.md
@@ -1,0 +1,32 @@
+# moshi-adapters
+
+Moshi JsonAdapters for [kotlinx.collections.immutable](https://github.com/Kotlin/kotlinx.collections.immutable) collection types
+
+## Usage
+
+Gradle dependency
+
+```kotlin
+dependencies {
+  implementation("dev.zacsweers.moshix:moshi-adapters-kotlinx-immutable:<version>")
+}
+```
+## Immutable Collection Adapters
+
+Use `addKotlinXImmutableAdapters` to add `PersistentListJsonAdapterFactory` and `PersistentMapJsonAdapterFactory` type
+adapters. These will deserialize standard JSON list and dictionary types into [kotlinx.collections.immutable](https://github.com/Kotlin/kotlinx.collections.immutable)
+`PersistentList` and `PersistentMap` types.
+
+```Kotlin
+val moshi = Moshi.Builder()
+  .addKotlinXImmutableAdapters()
+  .build()
+
+@JsonClass(generateAdapter = true)
+data class MyImmutableModel(
+  val stringList: PersistentList<String>,
+  val objList: PersistentList<SomeObject>,
+  val stringMap: PersistentMap<String, String>,
+  val objMap: PersistentMap<String, SomeObject>,  
+)
+```

--- a/moshi-adapters-kotlinx-immutable/api/moshi-adapters-kotlinx-immutable.api
+++ b/moshi-adapters-kotlinx-immutable/api/moshi-adapters-kotlinx-immutable.api
@@ -1,0 +1,14 @@
+public final class dev/zacsweers/moshix/immutable/adapters/ImmutableFactoriesMoshiBuilderKtxKt {
+	public static final fun addKotlinXImmutableAdapters (Lcom/squareup/moshi/Moshi$Builder;)Lcom/squareup/moshi/Moshi$Builder;
+}
+
+public final class dev/zacsweers/moshix/immutable/adapters/PersistentListJsonAdapterFactory : com/squareup/moshi/JsonAdapter$Factory {
+	public static final field INSTANCE Ldev/zacsweers/moshix/immutable/adapters/PersistentListJsonAdapterFactory;
+	public fun create (Ljava/lang/reflect/Type;Ljava/util/Set;Lcom/squareup/moshi/Moshi;)Lcom/squareup/moshi/JsonAdapter;
+}
+
+public final class dev/zacsweers/moshix/immutable/adapters/PersistentMapJsonAdapterFactory : com/squareup/moshi/JsonAdapter$Factory {
+	public static final field INSTANCE Ldev/zacsweers/moshix/immutable/adapters/PersistentMapJsonAdapterFactory;
+	public fun create (Ljava/lang/reflect/Type;Ljava/util/Set;Lcom/squareup/moshi/Moshi;)Lcom/squareup/moshi/JsonAdapter;
+}
+

--- a/moshi-adapters-kotlinx-immutable/build.gradle.kts
+++ b/moshi-adapters-kotlinx-immutable/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+  alias(libs.plugins.kotlinJvm)
+  alias(libs.plugins.ksp)
+  alias(libs.plugins.mavenPublish)
+}
+
+tasks.named<KotlinCompile>("compileTestKotlin") {
+  compilerOptions { freeCompilerArgs.add("-opt-in=kotlin.ExperimentalStdlibApi") }
+}
+
+dependencies {
+  implementation(libs.moshi)
+  implementation(libs.kotlinx.collections.immutable)
+  kspTest(libs.moshi.codegen)
+  testImplementation(libs.moshi.kotlin)
+  testImplementation(libs.okhttp)
+  testImplementation(libs.okhttp.mockwebserver)
+  testImplementation(libs.retrofit)
+  testImplementation(libs.retrofit.moshi)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+}

--- a/moshi-adapters-kotlinx-immutable/gradle.properties
+++ b/moshi-adapters-kotlinx-immutable/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=Moshi Kotlinx Immutable Collection Adapters
+POM_ARTIFACT_ID=moshi-adapters-kotlinx-immutable
+POM_PACKAGING=jar

--- a/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/ImmutableFactoriesMoshiBuilderKtx.kt
+++ b/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/ImmutableFactoriesMoshiBuilderKtx.kt
@@ -1,0 +1,11 @@
+package dev.zacsweers.moshix.immutable.adapters
+
+import com.squareup.moshi.Moshi
+
+/**
+ * Provides type adapters for [kotlinx.collections.immutable.PersistentList] and [kotlinx.collections.immutable.PersistentMap]
+ * types. See [PersistentListJsonAdapterFactory] and [PersistentMapJsonAdapterFactory] for examples.
+ */
+public fun Moshi.Builder.addKotlinXImmutableAdapters(): Moshi.Builder =
+    this.add(PersistentListJsonAdapterFactory)
+        .add(PersistentMapJsonAdapterFactory)

--- a/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/PersistentListJsonAdapterFactory.kt
+++ b/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/PersistentListJsonAdapterFactory.kt
@@ -1,0 +1,69 @@
+package dev.zacsweers.moshix.immutable.adapters
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.rawType
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Applying [PersistentListJsonAdapterFactory] to your Moshi instance will allow serialization between
+ * JSON lists and [kotlinx.collections.immutable.PersistentList] types.
+ *
+ * Example:
+ * ```
+ * JSON:
+ * {
+ *   "strings": ["value1", "value2", "value3"],
+ *   "people": [
+ *     {"first": "Jane", "last": "Doe"},
+ *     {"first": "John", "last": "Doh"}
+ *   ]
+ * }
+ *
+ * val moshi = Moshi.Builder()
+ *   .add(PersistentListJsonAdapterFactory)
+ *   .build()
+ *
+ * @JsonClass(generateAdapter = true)
+ * data class Data(
+ *   val strings: PersistentList<String>,
+ *   val people: PersistentList<Person>
+ * )
+ * ```
+ */
+public object PersistentListJsonAdapterFactory : JsonAdapter.Factory {
+
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        if (!PersistentList::class.java.isAssignableFrom(type.rawType) || type !is ParameterizedType) {
+            return null
+        }
+        val adapter = moshi.adapter(type.actualTypeArguments[0].rawType)
+        return PersistentListJsonAdapter(adapter).nullSafe()
+    }
+}
+
+private class PersistentListJsonAdapter<E>(private val adapter: JsonAdapter<E>) : JsonAdapter<PersistentList<E>>() {
+
+    override fun fromJson(reader: JsonReader): PersistentList<E> {
+        val listBuilder = persistentListOf<E>().builder()
+        reader.beginArray()
+        while (reader.hasNext()) {
+            listBuilder.add(
+                adapter.fromJson(reader) ?: error("[PersistentListJsonAdapter] Error parsing item: $reader")
+            )
+        }
+        reader.endArray()
+        return listBuilder.build()
+    }
+
+    override fun toJson(writer: JsonWriter, value: PersistentList<E>?) {
+        writer.beginArray()
+        value?.forEach { adapter.toJson(writer, it) }
+        writer.endArray()
+    }
+}

--- a/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/PersistentMapJsonAdapterFactory.kt
+++ b/moshi-adapters-kotlinx-immutable/src/main/kotlin/dev/zacsweers/moshix/immutable/adapters/PersistentMapJsonAdapterFactory.kt
@@ -1,0 +1,100 @@
+package dev.zacsweers.moshix.immutable.adapters
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.rawType
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+/**
+ * Applying [PersistentMapJsonAdapterFactory] to your Moshi instance will allow serialization between
+ * JSON dictionary and [kotlinx.collections.immutable.PersistentMap] types.
+ *
+ * Example:
+ * ```
+ * JSON:
+ * {
+ *   "stringMap": {
+ *     "a": "1",
+ *     "b": "2",
+ *     "c": "3"
+ *   },
+ *   "objMap": {
+ *     "a": {"value": "test1"},
+ *     "b": {"value": "test2"},
+ *     "c": {"value": "test3"}
+ *   }
+ * }
+ *
+ * val moshi = Moshi.Builder()
+ *   .add(PersistentMapJsonAdapterFactory)
+ *   .build()
+ *
+ * @JsonClass(generateAdapter = true)
+ * data class Data(
+ *   val strings: PersistentMap<String, String>,
+ *   val people: PersistentMap<String, SimpleValueObject>
+ * )
+ *
+ * @JsonClass(generateAdapter = true)
+ * private data class SimpleValueObject(val value: String)
+ * ```
+ */
+public object PersistentMapJsonAdapterFactory : JsonAdapter.Factory {
+
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? {
+        if (!PersistentMap::class.java.isAssignableFrom(type.rawType)
+            || type !is ParameterizedType
+            || annotations.isNotEmpty()
+            || type.actualTypeArguments.size != 2
+        ) {
+            return null
+        }
+
+        val keyType = type.actualTypeArguments[0]
+        val valueType = type.actualTypeArguments[1]
+
+        val keyAdapter = moshi.adapter(keyType.rawType)
+        val valueAdapter = moshi.adapter(valueType.rawType)
+
+        return PersistentMapJsonAdapter(
+            keyAdapter = keyAdapter,
+            valueAdapter = valueAdapter,
+        ).nullSafe()
+    }
+}
+
+private class PersistentMapJsonAdapter<K, V>(
+    private val keyAdapter: JsonAdapter<K>,
+    private val valueAdapter: JsonAdapter<V>,
+) : JsonAdapter<PersistentMap<K, V?>>() {
+
+    override fun fromJson(reader: JsonReader): PersistentMap<K, V?> {
+        val result = persistentMapOf<K, V?>().builder()
+        reader.beginObject()
+        while (reader.hasNext()) {
+            reader.promoteNameToValue()
+            val name = keyAdapter.fromJson(reader)
+            val value = valueAdapter.fromJson(reader)
+            if (name != null) {
+                result[name] = value
+            }
+        }
+        reader.endObject()
+        return result.build()
+    }
+
+    override fun toJson(writer: JsonWriter, map: PersistentMap<K, V?>?) {
+        writer.beginObject()
+        map?.forEach { (key, value) ->
+            writer.promoteValueToName()
+            keyAdapter.toJson(writer, key)
+            valueAdapter.toJson(writer, value)
+        }
+        writer.endObject()
+    }
+}

--- a/moshi-adapters-kotlinx-immutable/src/test/kotlin/dev/zacsweers/moshix/adapters/ImmutableTypesAdaptersTest.kt
+++ b/moshi-adapters-kotlinx-immutable/src/test/kotlin/dev/zacsweers/moshix/adapters/ImmutableTypesAdaptersTest.kt
@@ -1,0 +1,127 @@
+package dev.zacsweers.moshix.adapters
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.JsonClass
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.zacsweers.moshix.immutable.adapters.addKotlinXImmutableAdapters
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import org.junit.Test
+
+class ImmutableTypesAdaptersTest {
+
+    // Will be deserialized into a `PersistentList<String>`
+    private val testListOfStringsJson = """
+        {
+            "stringList": ["a", "b", "c"]
+        }
+    """.trimIndent()
+
+    // Will be deserialized into a `PersistentList<SimpleObject>`
+    private val testListOfObjectsJson = """
+        {
+            "objList": [
+                {"value": "test1"},
+                {"value": "test2"}
+            ]
+        }
+    """.trimIndent()
+
+    // Will be deserialized into a `PersistentMap<String, String>`
+    private val testMapOfStringsJson = """
+        {
+            "stringMap": {
+                "a": "1",
+                "b": "2",
+                "c": "3"
+            }
+        }
+    """.trimIndent()
+
+    // Will be deserialized into a `PersistentMap<String, SimpleObject>`
+    private val testMapOfObjectsJson = """
+        {
+            "objMap": {
+                "a": {"value": "test1"},
+                "b": {"value": "test2"},
+                "c": {"value": "test3"}
+            }
+        }
+    """.trimIndent()
+
+    private val moshi = Moshi.Builder()
+        .addKotlinXImmutableAdapters()
+        .addLast(KotlinJsonAdapterFactory())
+        .build()
+
+    @Test
+    fun `test immutable type deserialization for PersistentList of Strings`() {
+        val adapter = moshi.adapter(ListOfStringsType::class.java)
+        val response = adapter.fromJson(testListOfStringsJson)
+        assertThat(response?.stringList)
+            .isEqualTo(persistentListOf("a", "b", "c"))
+    }
+
+    @Test
+    fun `test immutable type deserialization for PersistentList of Objects`() {
+        val adapter = moshi.adapter(ListOfObjectsType::class.java)
+        val response = adapter.fromJson(testListOfObjectsJson)
+        assertThat(response?.objList)
+            .isEqualTo(
+                persistentListOf(
+                    SimpleObject("test1"),
+                    SimpleObject("test2"),
+                )
+            )
+    }
+
+    @Test
+    fun `test immutable type deserialization for PersistentMap of String to String`() {
+        val adapter = moshi.adapter(MapOfStringsType::class.java)
+        val response = adapter.fromJson(testMapOfStringsJson)
+        assertThat(response?.stringMap)
+            .isEqualTo(persistentMapOf("a" to "1", "b" to "2", "c" to "3"))
+    }
+
+    @Test
+    fun `test immutable type deserialization for PersistentMap of String to Object`() {
+        val adapter = moshi.adapter(MapOfObjectsType::class.java)
+        val response = adapter.fromJson(testMapOfObjectsJson)
+        assertThat(response?.objMap)
+            .isEqualTo(
+                persistentMapOf(
+                    "a" to SimpleObject("test1"),
+                    "b" to SimpleObject("test2"),
+                    "c" to SimpleObject("test3"),
+                )
+            )
+    }
+}
+
+@JsonClass(generateAdapter = true)
+internal data class ListOfStringsType(
+    val stringList: PersistentList<String>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class ListOfObjectsType(
+    val objList: PersistentList<SimpleObject>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class MapOfStringsType(
+    val stringMap: PersistentMap<String, String>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class MapOfObjectsType(
+    val objMap: PersistentMap<String, SimpleObject>,
+)
+
+@JsonClass(generateAdapter = true)
+internal data class SimpleObject(
+    val value: String
+)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,6 +65,7 @@ rootProject.name = "moshix-root"
 
 include(
   ":moshi-adapters",
+  ":moshi-adapters-kotlinx-immutable",
   ":moshi-ir:moshi-compiler-plugin",
   ":moshi-ir:moshi-kotlin-tests",
   ":moshi-ir:moshi-kotlin-tests:extra-moshi-test-module",


### PR DESCRIPTION
Resolve issue https://github.com/ZacSweers/MoshiX/issues/460

Moshi JsonAdapters for [kotlinx.collections.immutable](https://github.com/Kotlin/kotlinx.collections.immutable) collection types

Note the JsonAdapterFactory implementations in this PR are similar to the core Moshi versions of the adaptors (eg: [MapJsonAdapter.kt](https://github.com/square/moshi/blob/master/moshi/src/main/java/com/squareup/moshi/MapJsonAdapter.kt)).

## Usage

Gradle dependency

```kotlin
dependencies {
  implementation("dev.zacsweers.moshix:moshi-adapters-kotlinx-immutable:<version>")
}
```
## Immutable Collection Adapters

Use `addKotlinXImmutableAdapters()` to add `PersistentListJsonAdapterFactory` and `PersistentMapJsonAdapterFactory` type adapters. These will deserialize standard JSON list and dictionary types into [kotlinx.collections.immutable](https://github.com/Kotlin/kotlinx.collections.immutable) `PersistentList` and `PersistentMap` types.

```Kotlin
val moshi = Moshi.Builder()
  .addKotlinXImmutableAdapters()
  .build()

@JsonClass(generateAdapter = true)
data class MyImmutableModel(
  val stringList: PersistentList<String>, // Supports List of Strings
  val objList: PersistentList<SomeObject>, // Also supports List of Objects
  val stringMap: PersistentMap<String, String>, // Supports Map of <Strings, String>
  val objMap: PersistentMap<String, SomeObject>, // Also supports Map of <String, Object>
)
```
