### PR TITLE
Fix generated Proguard rules not using valid fully qualified name

### DIFF
--- a/moshi-proguard-rule-gen/src/main/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessor.kt
+++ b/moshi-proguard-rule-gen/src/main/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessor.kt
@@ -131,7 +131,8 @@ public class MoshiProguardGenSymbolProcessor(private val environment: SymbolProc
                 val adapterCanonicalName =
                   ClassName(targetType.packageName, adapterName).canonicalName
                 for (target in nestedSealedClassNames.sorted()) {
-                  writer.appendLine("-if class $target")
+                  val targetReflectionName = target.reflectionName()
+                  writer.appendLine("-if class $targetReflectionName")
                   writer.appendLine("-keep class $adapterCanonicalName {")
                   // Keep the constructor for Moshi's reflective lookup
                   val constructorArgs = adapterConstructorParams.joinToString(",")

--- a/moshi-proguard-rule-gen/src/main/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessor.kt
+++ b/moshi-proguard-rule-gen/src/main/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessor.kt
@@ -128,12 +128,12 @@ public class MoshiProguardGenSymbolProcessor(private val environment: SymbolProc
                 writer.appendLine(
                   "\n# Conditionally keep this adapter for every possible nested subtype that uses it."
                 )
-                val adapterCanonicalName =
-                  ClassName(targetType.packageName, adapterName).canonicalName
+                val adapterReflectionName =
+                  ClassName(targetType.packageName, adapterName).reflectionName()
                 for (target in nestedSealedClassNames.sorted()) {
                   val targetReflectionName = target.reflectionName()
                   writer.appendLine("-if class $targetReflectionName")
-                  writer.appendLine("-keep class $adapterCanonicalName {")
+                  writer.appendLine("-keep class $adapterReflectionName {")
                   // Keep the constructor for Moshi's reflective lookup
                   val constructorArgs = adapterConstructorParams.joinToString(",")
                   writer.appendLine("    public <init>($constructorArgs);")

--- a/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
+++ b/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
@@ -307,6 +307,7 @@ sealed class BaseType {
         "moshi-test.BaseType" ->
           assertThat(generatedFile.readText().trimIndent())
             .isEqualTo(
+              // $ in multiline strings: https://youtrack.jetbrains.com/issue/KT-2425
               """
                   -if class test.BaseType
                   -keepnames class test.BaseType
@@ -316,19 +317,19 @@ sealed class BaseType {
                   }
 
                   # Conditionally keep this adapter for every possible nested subtype that uses it.
-                  -if class test.BaseType.TypeA
+                  -if class test.BaseType${'$'}TypeA
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeB
+                  -if class test.BaseType${'$'}TypeB
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeC
+                  -if class test.BaseType${'$'}TypeC
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeC.TypeCImpl
+                  -if class test.BaseType${'$'}TypeC${'$'}TypeCImpl
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }

--- a/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
+++ b/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
@@ -82,21 +82,22 @@ class MoshiProguardGenSymbolProcessorTest(private val useKSP2: Boolean) {
         "moshi-test.BaseType" ->
           assertThat(generatedFile.readText().trimIndent())
             .isEqualTo(
+              // $ in multiline strings: https://youtrack.jetbrains.com/issue/KT-2425
               """
                   # Conditionally keep this adapter for every possible nested subtype that uses it.
-                  -if class test.BaseType.TypeA
+                  -if class test.BaseType${'$'}TypeA
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeB
+                  -if class test.BaseType${'$'}TypeB
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeC
+                  -if class test.BaseType${'$'}TypeC
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.BaseType.TypeC.TypeCImpl
+                  -if class test.BaseType${'$'}TypeC${'$'}TypeCImpl
                   -keep class test.BaseTypeJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
@@ -118,7 +119,6 @@ class MoshiProguardGenSymbolProcessorTest(private val useKSP2: Boolean) {
       import com.squareup.moshi.Json
       import com.squareup.moshi.JsonClass
       import dev.zacsweers.moshix.sealed.annotations.TypeLabel
-      import dev.zacsweers.moshix.sealed.annotations.NestedSealed
       import dev.zacsweers.moshix.sealed.annotations.DefaultObject
 
       @JsonClass(generateAdapter = true, generator = "sealed:type")
@@ -149,13 +149,14 @@ class MoshiProguardGenSymbolProcessorTest(private val useKSP2: Boolean) {
         "moshi-test.Message" ->
           assertThat(generatedFile.readText().trimIndent())
             .isEqualTo(
+              // $ in multiline strings: https://youtrack.jetbrains.com/issue/KT-2425
               """
                   # Conditionally keep this adapter for every possible nested subtype that uses it.
-                  -if class test.Message.Success
+                  -if class test.Message${'$'}Success
                   -keep class test.MessageJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }
-                  -if class test.Message.Unknown
+                  -if class test.Message${'$'}Unknown
                   -keep class test.MessageJsonAdapter {
                       public <init>(com.squareup.moshi.Moshi);
                   }

--- a/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
+++ b/moshi-proguard-rule-gen/src/test/kotlin/dev/zacsweers/moshix/proguardgen/MoshiProguardGenSymbolProcessorTest.kt
@@ -186,10 +186,10 @@ class MoshiProguardGenSymbolProcessorTest(private val useKSP2: Boolean) {
           import com.squareup.moshi.JsonClass
           import dev.zacsweers.moshix.sealed.annotations.TypeLabel
           import dev.zacsweers.moshix.sealed.annotations.DefaultObject
-  
+
           @JsonClass(generateAdapter = true, generator = "sealed:type")
           sealed class Message {
-          
+
               @TypeLabel("success")
               @JsonClass(generateAdapter = true)
               data class Success(
@@ -200,7 +200,8 @@ class MoshiProguardGenSymbolProcessorTest(private val useKSP2: Boolean) {
               @DefaultObject
               object Unknown : Message()
           }
-          """.trimIndent(),
+          """
+            .trimIndent(),
         )
 
       val compilation = prepareCompilation(source)


### PR DESCRIPTION
This PR fixes https://github.com/ZacSweers/MoshiX/issues/624. 

KotlinPoet's [ClassName](https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/-class-name/index.html).toString() does not yield a valid fully qualified path for e.g. nested classes, or when backticks are used in the package name to escape [reserved keywords](https://kotlinlang.org/docs/keyword-reference.html#modifier-keywords). Instead, [`ClassName.reflectionName()`](https://square.github.io/kotlinpoet/1.x/kotlinpoet/kotlinpoet/com.squareup.kotlinpoet/-class-name/reflection-name.html) should be used for that.

☝️ This is the only functional change.

The other changes in this PR are:
- Fix the existing tests asserting incorrect expected values. These tests started failing as soon as `reflectionName()` was used. 👌 
- Add a test for https://github.com/ZacSweers/MoshiX/issues/624. I just cherry picked 3 reserved keywords per category. These could be extended to include more, or reduced to a single keyword. It's currently not optimised at all, as it simply repeats the compile -> validation cycle 3*3 times. (Compiling once would probably be more efficient, but also harder to do assertions on the output)

Thanks to @sav007 for the hint in https://github.com/ZacSweers/MoshiX/issues/415#issuecomment-1513553223