### PR TITLE
Replace all usages of findProperty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,11 @@ concurrency:
 
 jobs:
   build:
-    name: 'KSP ${{ matrix.ksp_enabled }} / K2 ${{ matrix.k2_enabled }}'
+    name: 'KSP ${{ matrix.ksp_enabled }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         ksp_enabled: [ true, false ]
-        k2_enabled: [ true, false ]
       fail-fast: false
 
     steps:
@@ -39,7 +38,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build project
-        run: ./gradlew build check -Pmoshix.useKsp=${{ matrix.ksp_enabled }} -Pkotlin.experimental.tryK2=${{ matrix.k2_enabled }} --quiet
+        run: ./gradlew build check -Pmoshix.useKsp=${{ matrix.ksp_enabled }} --quiet
 
   publish-snapshot:
     needs: 'build'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,9 @@ spotless {
 subprojects {
   pluginManager.withPlugin("java") {
     // javaReleaseVersion can be set to override the global version
-    val jvmTargetProvider = providers.gradleProperty("moshix.javaReleaseVersion")
+    val jvmTargetProvider =
+      providers
+        .gradleProperty("moshix.javaReleaseVersion")
         .orElse(libs.versions.jvmTarget)
         .map(String::toInt)
     configure<JavaPluginExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,8 +76,7 @@ spotless {
 subprojects {
   pluginManager.withPlugin("java") {
     // javaReleaseVersion can be set to override the global version
-    val jvmTargetProvider =
-      provider<String> { findProperty("moshix.javaReleaseVersion") as? String? }
+    val jvmTargetProvider = providers.gradleProperty("moshix.javaReleaseVersion")
         .orElse(libs.versions.jvmTarget)
         .map(String::toInt)
     configure<JavaPluginExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,9 +76,9 @@ spotless {
 subprojects {
   pluginManager.withPlugin("java") {
     // javaReleaseVersion can be set to override the global version
+    // Can't use providers.gradleProperty() because it doesn't work on subprojects
     val jvmTargetProvider =
-      providers
-        .gradleProperty("moshix.javaReleaseVersion")
+      provider<String> { findProperty("moshix.javaReleaseVersion") as? String? }
         .orElse(libs.versions.jvmTarget)
         .map(String::toInt)
     configure<JavaPluginExtension> {

--- a/moshi-ir/moshi-gradle-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-gradle-plugin/build.gradle.kts
@@ -67,15 +67,15 @@ tasks.withType<KotlinCompile>().configureEach {
 tasks.matching { it.name == "sourcesJar" }.configureEach { dependsOn(copyVersionTemplatesProvider) }
 
 gradlePlugin {
-  website = project.findProperty("POM_URL") as String
-  vcsUrl = project.findProperty("POM_SCM_URL") as String
+  website = providers.gradleProperty("POM_URL").get()
+  vcsUrl = providers.gradleProperty("POM_SCM_URL").get()
 
   plugins {
     register("moshiPlugin") {
       id = "dev.zacsweers.moshix"
-      displayName = project.findProperty("POM_NAME") as String
+      displayName = providers.gradleProperty("POM_NAME").get()
       implementationClass = "dev.zacsweers.moshix.ir.gradle.MoshiGradleSubplugin"
-      description = project.findProperty("POM_DESCRIPTION") as String
+      description = providers.gradleProperty("POM_DESCRIPTION").get()
     }
   }
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/LocalProperties.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/LocalProperties.kt
@@ -1,0 +1,33 @@
+package dev.zacsweers.moshix.ir.gradle
+
+import java.util.Properties
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+
+internal fun Project.createPropertiesProvider(filePath: String): Provider<Properties> {
+  return project.providers.of(LocalProperties::class.java) {
+    it.parameters.propertiesFile.set(project.layout.projectDirectory.file(filePath))
+  }
+}
+
+/** Implementation of provider holding a local properties file's parsed [Properties]. */
+internal abstract class LocalProperties : ValueSource<Properties, LocalProperties.Parameters> {
+  interface Parameters : ValueSourceParameters {
+    val propertiesFile: RegularFileProperty
+  }
+
+  override fun obtain(): Properties? {
+    val provider = parameters.propertiesFile
+    if (!provider.isPresent) {
+      return null
+    }
+    val propertiesFile = provider.asFile.get()
+    if (!propertiesFile.exists()) {
+      return null
+    }
+    return Properties().apply { propertiesFile.inputStream().use(::load) }
+  }
+}

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.gradle
 
+import com.google.devtools.ksp.gradle.KspExtension
+import dev.zacsweers.moshi.ir.gradle.VERSION
+import dev.zacsweers.moshix.ir.gradle.MoshiGradleSubplugin.Companion.SUPPORTED_PLATFORMS
+import java.util.Locale.US
 import javax.inject.Inject
+import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
-abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) {
+abstract class MoshiPluginExtension
+@Inject
+constructor(objects: ObjectFactory, providers: ProviderFactory) {
   val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(true)
   /** Enables debug logging. Useful mostly for helping report bugs/issues. */
   val debug: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(false)
@@ -21,4 +31,62 @@ abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) 
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   /** Enables moshi-sealed code gen. Disabled by default. */
   val enableSealed: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+  /**
+   * Enables generation of proguard rules for adapters via KSP. Enabled by default and configurable
+   * via the `moshix.generateProguardRules` Gradle property.
+   */
+  val generateProguardRules: Property<Boolean> =
+    objects
+      .property(Boolean::class.java)
+      .convention(
+        providers
+          .gradleProperty("moshix.generateProguardRules")
+          .map { it.toBooleanStrictOrNull() ?: true }
+          .orElse(true)
+      )
+
+  internal fun apply(target: Project) {
+    if (generateProguardRules.get()) {
+      try {
+        target.pluginManager.apply("com.google.devtools.ksp")
+      } catch (e: Exception) {
+        // KSP not on the classpath, ask them to add it
+        error(
+          "MoshiX proguard rule generation requires KSP to be applied to the project. " +
+            "Please apply the KSP Gradle plugin ('com.google.devtools.ksp') to your buildscript and try again."
+        )
+      }
+
+      fun addKspDep(configurationName: String) {
+        target.dependencies.add(
+          configurationName,
+          "dev.zacsweers.moshix:moshi-proguard-rule-gen:$VERSION",
+        )
+      }
+
+      // Add the KSP dependency to the appropriate configurations
+      // In KMP, we only add to androidJvm/jvm targets
+      val kExtension = target.kotlinExtension
+      if (kExtension is KotlinMultiplatformExtension) {
+        kExtension.targets
+          .matching { it.platformType in SUPPORTED_PLATFORMS }
+          .configureEach {
+            addKspDep(
+              "ksp${it.targetName.replaceFirstChar { if (it.isLowerCase()) it.titlecase(US) else it.toString() }}"
+            )
+          }
+      } else {
+        addKspDep("ksp")
+      }
+      target.extensions.configure(KspExtension::class.java) {
+        // Enable core moshi proguard rule gen
+        it.arg("moshi.generateCoreMoshiProguardRules", "true")
+        // Disable moshi's KSP codegen, we're doing it ourselves
+        it.excludeProcessor(
+          "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider"
+        )
+      }
+    }
+  }
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
@@ -2,21 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.gradle
 
-import com.google.devtools.ksp.gradle.KspExtension
-import dev.zacsweers.moshi.ir.gradle.VERSION
-import dev.zacsweers.moshix.ir.gradle.MoshiGradleSubplugin.Companion.SUPPORTED_PLATFORMS
-import java.util.Locale.US
 import javax.inject.Inject
-import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.ProviderFactory
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
-abstract class MoshiPluginExtension
-@Inject
-constructor(objects: ObjectFactory, providers: ProviderFactory) {
+abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) {
   val enabled: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(true)
   /** Enables debug logging. Useful mostly for helping report bugs/issues. */
   val debug: Property<Boolean> = objects.property(Boolean::class.javaObjectType).convention(false)
@@ -31,62 +21,4 @@ constructor(objects: ObjectFactory, providers: ProviderFactory) {
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   /** Enables moshi-sealed code gen. Disabled by default. */
   val enableSealed: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
-
-  /**
-   * Enables generation of proguard rules for adapters via KSP. Enabled by default and configurable
-   * via the `moshix.generateProguardRules` Gradle property.
-   */
-  val generateProguardRules: Property<Boolean> =
-    objects
-      .property(Boolean::class.java)
-      .convention(
-        providers
-          .gradleProperty("moshix.generateProguardRules")
-          .map { it.toBooleanStrictOrNull() ?: true }
-          .orElse(true)
-      )
-
-  internal fun apply(target: Project) {
-    if (generateProguardRules.get()) {
-      try {
-        target.pluginManager.apply("com.google.devtools.ksp")
-      } catch (e: Exception) {
-        // KSP not on the classpath, ask them to add it
-        error(
-          "MoshiX proguard rule generation requires KSP to be applied to the project. " +
-            "Please apply the KSP Gradle plugin ('com.google.devtools.ksp') to your buildscript and try again."
-        )
-      }
-
-      fun addKspDep(configurationName: String) {
-        target.dependencies.add(
-          configurationName,
-          "dev.zacsweers.moshix:moshi-proguard-rule-gen:$VERSION",
-        )
-      }
-
-      // Add the KSP dependency to the appropriate configurations
-      // In KMP, we only add to androidJvm/jvm targets
-      val kExtension = target.kotlinExtension
-      if (kExtension is KotlinMultiplatformExtension) {
-        kExtension.targets
-          .matching { it.platformType in SUPPORTED_PLATFORMS }
-          .configureEach {
-            addKspDep(
-              "ksp${it.targetName.replaceFirstChar { if (it.isLowerCase()) it.titlecase(US) else it.toString() }}"
-            )
-          }
-      } else {
-        addKspDep("ksp")
-      }
-      target.extensions.configure(KspExtension::class.java) {
-        // Enable core moshi proguard rule gen
-        it.arg("moshi.generateCoreMoshiProguardRules", "true")
-        // Disable moshi's KSP codegen, we're doing it ourselves
-        it.excludeProcessor(
-          "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider"
-        )
-      }
-    }
-  }
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.gradle
 
+import com.google.devtools.ksp.gradle.KspExtension
 import dev.zacsweers.moshi.ir.gradle.VERSION
+import java.util.Locale.US
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -16,13 +20,65 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
 
-  internal companion object {
+  private companion object {
     val SUPPORTED_PLATFORMS = setOf(KotlinPlatformType.androidJvm, KotlinPlatformType.jvm)
+    const val GENERATE_PROGUARD_RULES_KEY = "moshix.generateProguardRules"
   }
 
   override fun apply(target: Project) {
-    val extension = target.extensions.create("moshi", MoshiPluginExtension::class.java)
-    target.afterEvaluate { extension.apply(target) }
+    target.extensions.create("moshi", MoshiPluginExtension::class.java)
+
+    val localGradlePropertyProvider =
+      target.createPropertiesProvider("gradle.properties").map {
+        it.getProperty(GENERATE_PROGUARD_RULES_KEY)
+      }
+
+    if (
+      localGradlePropertyProvider
+        .orElse(target.providers.gradleProperty(GENERATE_PROGUARD_RULES_KEY))
+        .orNull
+        ?.toBoolean() != false
+    ) {
+      try {
+        target.pluginManager.apply("com.google.devtools.ksp")
+      } catch (e: Exception) {
+        // KSP not on the classpath, ask them to add it
+        error(
+          "MoshiX proguard rule generation requires KSP to be applied to the project. " +
+            "Please apply the KSP Gradle plugin ('com.google.devtools.ksp') to your buildscript and try again."
+        )
+      }
+
+      fun addKspDep(configurationName: String) {
+        target.dependencies.add(
+          configurationName,
+          "dev.zacsweers.moshix:moshi-proguard-rule-gen:$VERSION",
+        )
+      }
+
+      // Add the KSP dependency to the appropriate configurations
+      // In KMP, we only add to androidJvm/jvm targets
+      val kExtension = target.kotlinExtension
+      if (kExtension is KotlinMultiplatformExtension) {
+        kExtension.targets
+          .matching { it.platformType in SUPPORTED_PLATFORMS }
+          .configureEach {
+            addKspDep(
+              "ksp${it.targetName.replaceFirstChar { if (it.isLowerCase()) it.titlecase(US) else it.toString() }}"
+            )
+          }
+      } else {
+        addKspDep("ksp")
+      }
+      target.extensions.configure(KspExtension::class.java) {
+        // Enable core moshi proguard rule gen
+        it.arg("moshi.generateCoreMoshiProguardRules", "true")
+        // Disable moshi's KSP codegen, we're doing it ourselves
+        it.excludeProcessor(
+          "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider"
+        )
+      }
+    }
   }
 
   override fun getCompilerPluginId(): String = "dev.zacsweers.moshix.compiler"

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -26,7 +26,7 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
 
   override fun apply(target: Project) {
     target.extensions.create("moshi", MoshiPluginExtension::class.java)
-    if (target.findProperty("moshix.generateProguardRules")?.toString()?.toBoolean() != false) {
+    if (target.providers.gradleProperty("moshix.generateProguardRules").orNull?.toBoolean() != false) {
       try {
         target.pluginManager.apply("com.google.devtools.ksp")
       } catch (e: Exception) {

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -2,16 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.gradle
 
-import com.google.devtools.ksp.gradle.KspExtension
 import dev.zacsweers.moshi.ir.gradle.VERSION
-import java.util.Locale.US
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -20,55 +16,13 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 
 class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
 
-  private companion object {
+  internal companion object {
     val SUPPORTED_PLATFORMS = setOf(KotlinPlatformType.androidJvm, KotlinPlatformType.jvm)
   }
 
   override fun apply(target: Project) {
-    target.extensions.create("moshi", MoshiPluginExtension::class.java)
-    if (
-      target.providers.gradleProperty("moshix.generateProguardRules").orNull?.toBoolean() != false
-    ) {
-      try {
-        target.pluginManager.apply("com.google.devtools.ksp")
-      } catch (e: Exception) {
-        // KSP not on the classpath, ask them to add it
-        error(
-          "MoshiX proguard rule generation requires KSP to be applied to the project. " +
-            "Please apply the KSP Gradle plugin ('com.google.devtools.ksp') to your buildscript and try again."
-        )
-      }
-
-      fun addKspDep(configurationName: String) {
-        target.dependencies.add(
-          configurationName,
-          "dev.zacsweers.moshix:moshi-proguard-rule-gen:$VERSION",
-        )
-      }
-
-      // Add the KSP dependency to the appropriate configurations
-      // In KMP, we only add to androidJvm/jvm targets
-      val kExtension = target.kotlinExtension
-      if (kExtension is KotlinMultiplatformExtension) {
-        kExtension.targets
-          .matching { it.platformType in SUPPORTED_PLATFORMS }
-          .configureEach {
-            addKspDep(
-              "ksp${it.targetName.replaceFirstChar { if (it.isLowerCase()) it.titlecase(US) else it.toString() }}"
-            )
-          }
-      } else {
-        addKspDep("ksp")
-      }
-      target.extensions.configure(KspExtension::class.java) {
-        // Enable core moshi proguard rule gen
-        it.arg("moshi.generateCoreMoshiProguardRules", "true")
-        // Disable moshi's KSP codegen, we're doing it ourselves
-        it.excludeProcessor(
-          "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider"
-        )
-      }
-    }
+    val extension = target.extensions.create("moshi", MoshiPluginExtension::class.java)
+    target.afterEvaluate { extension.apply(target) }
   }
 
   override fun getCompilerPluginId(): String = "dev.zacsweers.moshix.compiler"

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -26,7 +26,9 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
 
   override fun apply(target: Project) {
     target.extensions.create("moshi", MoshiPluginExtension::class.java)
-    if (target.providers.gradleProperty("moshix.generateProguardRules").orNull?.toBoolean() != false) {
+    if (
+      target.providers.gradleProperty("moshix.generateProguardRules").orNull?.toBoolean() != false
+    ) {
       try {
         target.pluginManager.apply("com.google.devtools.ksp")
       } catch (e: Exception) {

--- a/moshi-ir/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/build.gradle.kts
@@ -26,24 +26,34 @@ kotlin.compilerOptions.optIn.add("kotlin.ExperimentalStdlibApi")
 
 moshi { enableSealed.set(true) }
 
-val proguardRuleValidator =
-  tasks.register("validateProguardRules") {
-    doNotTrackState("This is a validation task that should always run")
-    notCompatibleWithConfigurationCache("This task always runs")
-    doLast {
-      logger.lifecycle("Validating proguard rules")
-      val proguardRulesDir = project.file("build/generated/ksp/test/resources/META-INF/proguard")
-      check(proguardRulesDir.exists() && proguardRulesDir.listFiles()!!.isNotEmpty()) {
-        "No proguard rules found! Did you forget to apply the KSP Gradle plugin?"
-      }
-      logger.lifecycle("Proguard rules properly generated ✅ ")
-    }
-  }
+@CacheableTask
+abstract class ProguardRuleValidator : DefaultTask() {
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val proguardRulesDir: DirectoryProperty
 
-tasks
-  .withType<KotlinCompile>()
-  .named { it == "compileTestKotlin" }
-  .configureEach { finalizedBy(proguardRuleValidator) }
+  @get:OutputFile abstract val output: RegularFileProperty
+
+  @TaskAction
+  fun validate() {
+    logger.lifecycle("Validating proguard rules")
+    val proguardRulesDir = this@ProguardRuleValidator.proguardRulesDir.asFile.get()
+    check(proguardRulesDir.exists() && proguardRulesDir.walkTopDown().any()) {
+      "No proguard rules found! Did you forget to apply the KSP Gradle plugin?"
+    }
+    logger.lifecycle("Proguard rules properly generated ✅ ")
+    output.get().asFile.writeText("validated")
+  }
+}
+
+val proguardRuleValidator =
+  tasks.register<ProguardRuleValidator>("validateProguardRules") {
+    proguardRulesDir.set(
+      project.layout.buildDirectory.dir("generated/ksp/test/resources/META-INF/proguard")
+    )
+    output.set(project.layout.buildDirectory.file("moshix/validation/validated.txt"))
+    dependsOn(tasks.withType<KotlinCompile>().named { it == "compileTestKotlin" })
+  }
 
 dependencies {
   testImplementation("junit:junit:4.13.2")

--- a/moshi-ir/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
   alias(libs.plugins.ksp)
 }
 
+kotlin.compilerOptions.optIn.add("kotlin.ExperimentalStdlibApi")
+
 moshi { enableSealed.set(true) }
 
 val proguardRuleValidator =
@@ -38,15 +40,10 @@ val proguardRuleValidator =
     }
   }
 
-tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions { freeCompilerArgs.addAll("-opt-in=kotlin.ExperimentalStdlibApi") }
-  if (
-    name == "compileTestKotlin" &&
-      providers.gradleProperty("kotlin.experimental.tryK2").orNull != "true"
-  ) {
-    finalizedBy(proguardRuleValidator)
-  }
-}
+tasks
+  .withType<KotlinCompile>()
+  .named { it == "compileTestKotlin" }
+  .configureEach { finalizedBy(proguardRuleValidator) }
 
 dependencies {
   testImplementation("junit:junit:4.13.2")

--- a/moshi-ir/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/build.gradle.kts
@@ -40,7 +40,10 @@ val proguardRuleValidator =
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions { freeCompilerArgs.addAll("-opt-in=kotlin.ExperimentalStdlibApi") }
-  if (name == "compileTestKotlin" && providers.gradleProperty("kotlin.experimental.tryK2").orNull != "true") {
+  if (
+    name == "compileTestKotlin" &&
+      providers.gradleProperty("kotlin.experimental.tryK2").orNull != "true"
+  ) {
     finalizedBy(proguardRuleValidator)
   }
 }

--- a/moshi-ir/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/build.gradle.kts
@@ -40,7 +40,7 @@ val proguardRuleValidator =
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions { freeCompilerArgs.addAll("-opt-in=kotlin.ExperimentalStdlibApi") }
-  if (name == "compileTestKotlin" && project.findProperty("kotlin.experimental.tryK2") != "true") {
+  if (name == "compileTestKotlin" && providers.gradleProperty("kotlin.experimental.tryK2").orNull != "true") {
     finalizedBy(proguardRuleValidator)
   }
 }

--- a/moshi-ir/moshi-kotlin-tests/gradle.properties
+++ b/moshi-ir/moshi-kotlin-tests/gradle.properties
@@ -1,1 +1,0 @@
-moshix.generateProguardRules=true


### PR DESCRIPTION
It is not compatible with project isolation, `providers.gradleProperty` is however.

This PR also change all build script related usages, though this isn't needed for consumers of course.