### PR TITLE
Bump and add possibility to override Moshi version applied by IR plugin

### DIFF
--- a/moshi-ir/README.md
+++ b/moshi-ir/README.md
@@ -40,6 +40,8 @@ plugins {
 moshi {
   // Opt-in to enable moshi-sealed, disabled by default.
   enableSealed.set(true)
+  // You can use moshiVersion property to override version of Moshi dependency applied by IR plugin.
+  moshiVersion.set("1.15.1")
 }
 ```
 

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
@@ -21,4 +21,6 @@ abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) 
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   /** Enables moshi-sealed code gen. Disabled by default. */
   val enableSealed: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /** Moshi version to be used when applying dependency. */
+  val moshiVersion: Property<String> = objects.property(String::class.java).convention("1.15.1")
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -105,10 +105,10 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
 
     val generatedAnnotation = extension.generatedAnnotation.orNull
 
-    // Minimum Moshi version
+    val moshiVersion = extension.moshiVersion.get()
     project.dependencies.add(
       kotlinCompilation.implementationConfigurationName,
-      "com.squareup.moshi:moshi:1.15.1",
+      "com.squareup.moshi:moshi:$moshiVersion",
     )
 
     val enableSealed = extension.enableSealed.get()

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -108,7 +108,7 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     // Minimum Moshi version
     project.dependencies.add(
       kotlinCompilation.implementationConfigurationName,
-      "com.squareup.moshi:moshi:1.13.0",
+      "com.squareup.moshi:moshi:1.15.1",
     )
 
     val enableSealed = extension.enableSealed.get()


### PR DESCRIPTION
Two commits here:
1. Bump Moshi version applied by IR plugin from 1.13.0 to 1.15.1. 1.13.0 was released on 2021-12-08 and 1.15.1 was released on 2024-01-30, I think it makes sense to apply newest version. Also 1.15.1 is already widely used throughout the MoshiX repository.
2. Add possibility to override the version in case of somebody needs older or newer one, if it's there. It should be convenient to do this by utilizing simple property in Gradle plugin extension. Moved default value to property's convention as it makes sense to set the default version value as early as possible, and then only read it.