### PR TITLE
Add possibility to disable auto-application of Moshi dependency

### DIFF
--- a/moshi-ir/README.md
+++ b/moshi-ir/README.md
@@ -40,6 +40,8 @@ plugins {
 moshi {
   // Opt-in to enable moshi-sealed, disabled by default.
   enableSealed.set(true)
+  // Opt-out to disable auto-application of Moshi dependency, enabled by default.
+  applyMoshiDependency.set(false)
 }
 ```
 

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradlePluginExtension.kt
@@ -21,4 +21,10 @@ abstract class MoshiPluginExtension @Inject constructor(objects: ObjectFactory) 
   val generatedAnnotation: Property<String> = objects.property(String::class.java)
   /** Enables moshi-sealed code gen. Disabled by default. */
   val enableSealed: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /**
+   * Set this property to false to disable auto-application of the Moshi dependency. Enabled by
+   * default.
+   */
+  val applyMoshiDependency: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
 }

--- a/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
+++ b/moshi-ir/moshi-gradle-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/gradle/MoshiGradleSubplugin.kt
@@ -106,10 +106,13 @@ class MoshiGradleSubplugin : KotlinCompilerPluginSupportPlugin {
     val generatedAnnotation = extension.generatedAnnotation.orNull
 
     // Minimum Moshi version
-    project.dependencies.add(
-      kotlinCompilation.implementationConfigurationName,
-      "com.squareup.moshi:moshi:1.13.0",
-    )
+    val applyMoshiDependency = extension.applyMoshiDependency.get()
+    if (applyMoshiDependency) {
+      project.dependencies.add(
+        kotlinCompilation.implementationConfigurationName,
+        "com.squareup.moshi:moshi:1.13.0",
+      )
+    }
 
     val enableSealed = extension.enableSealed.get()
     if (enableSealed) {


### PR DESCRIPTION
This allows to rely on manually applied, possibly newer version of Moshi dependency, and not auto-adding older version unnecessarily by the IR plugin.