### PR TITLE
Migrate formatting to Kempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '23'
+
+      - uses: ZacSweers/kempt@main
+        with:
+          cache: true
+
   build:
     name: 'KSP ${{ matrix.ksp_enabled }}'
     runs-on: ubuntu-latest

--- a/.kempt.toml
+++ b/.kempt.toml
@@ -1,0 +1,32 @@
+# kempt configuration: https://github.com/ZacSweers/kempt
+
+[ktfmt]
+version = "0.64"
+
+[gjf]
+version = "1.35.0"
+
+[license-header]
+file = "config/license-header.txt"
+
+[ktfmt.license-header]
+excludes = "config/license-header-excludes-kt.txt"
+
+[paths]
+exclude = [
+  "**/build/**",
+  "**/.gradle/**",
+  "**/Dependencies.kt",
+]
+
+[ktfmt.paths]
+include = [
+  "**/*.kt",
+  "**/*.kts",
+]
+
+[gjf.paths]
+include = ["**/*.java"]
+
+[hook]
+mode = "format"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 import com.android.build.api.dsl.Lint
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.dokka.gradle.DokkaExtension
@@ -25,7 +12,6 @@ plugins {
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.dokka)
   alias(libs.plugins.mavenPublish) apply false
-  alias(libs.plugins.spotless)
   alias(libs.plugins.kotlinBinaryCompatibilityValidator)
   alias(libs.plugins.lint) apply false
   alias(libs.plugins.moshix) apply false
@@ -46,35 +32,6 @@ dokka {
   dokkaPublications.html {
     outputDirectory.set(rootDir.resolve("docs/api/0.x"))
     includes.from(project.layout.projectDirectory.file("README.md"))
-  }
-}
-
-val ktfmtVersion = libs.versions.ktfmt.get()
-
-spotless {
-  format("misc") {
-    target("*.md", ".gitignore")
-    trimTrailingWhitespace()
-    leadingTabsToSpaces(2)
-    endWithNewline()
-  }
-  java {
-    googleJavaFormat(libs.versions.gjf.get())
-    target("**/*.java")
-    targetExclude("**/spotless.java", "**/build/**", "**/.gradle/**")
-  }
-  kotlin {
-    ktfmt(ktfmtVersion).googleStyle()
-    target("**/*.kt")
-    trimTrailingWhitespace()
-    endWithNewline()
-    targetExclude("**/Dependencies.kt", "**/spotless.kt", "**/build/**")
-  }
-  kotlinGradle {
-    ktfmt(ktfmtVersion).googleStyle()
-    target("**/*.gradle.kts")
-    trimTrailingWhitespace()
-    endWithNewline()
   }
 }
 

--- a/config/license-header-excludes-kt.txt
+++ b/config/license-header-excludes-kt.txt
@@ -1,0 +1,1 @@
+**/Dependencies.kt

--- a/config/license-header.txt
+++ b/config/license-header.txt
@@ -1,0 +1,2 @@
+// Copyright (C) ${YEAR} Zac Sweers
+// SPDX-License-Identifier: Apache-2.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ kotlin = "2.4.0"
 kotlinCompileTesting = "0.13.0"
 kotlinpoet = "2.3.0"
 ksp = "2.3.9"
-ktfmt = "0.63"
+ktfmt = "0.64"
 moshi = "1.15.2"
 okio = "3.17.0"
 okhttp = "5.4.0"
@@ -38,7 +38,6 @@ lint = { id = "com.android.lint", version = "9.2.1" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.37.0" }
 mavenShadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }
 moshix = { id = "dev.zacsweers.moshix", version = "0.36.0" } # Always replaced by the local plugin
-spotless = { id = "com.diffplug.spotless", version = "8.7.0" }
 
 [libraries]
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/moshi-adapters/build.gradle.kts
+++ b/moshi-adapters/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublish)

--- a/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/AdaptedBy.kt
+++ b/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/AdaptedBy.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2014 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/JsonString.kt
+++ b/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/JsonString.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/TrackUnknownKeys.kt
+++ b/moshi-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/TrackUnknownKeys.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/AdaptedByTest.kt
+++ b/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/AdaptedByTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/JsonStringTest.kt
+++ b/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/JsonStringTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/TrackUnknownKeysTest.kt
+++ b/moshi-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/TrackUnknownKeysTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-immutable-adapters/build.gradle.kts
+++ b/moshi-immutable-adapters/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2024 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.ksp)

--- a/moshi-immutable-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/immutable/ImmutableCollectionsJsonAdapterFactory.kt
+++ b/moshi-immutable-adapters/src/main/kotlin/dev/zacsweers/moshix/adapters/immutable/ImmutableCollectionsJsonAdapterFactory.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters.immutable
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-immutable-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/immutable/ImmutableCollectionsJsonAdapterFactoryTest.kt
+++ b/moshi-immutable-adapters/src/test/kotlin/dev/zacsweers/moshix/adapters/immutable/ImmutableCollectionsJsonAdapterFactoryTest.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.adapters.immutable
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-compiler-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-compiler-plugin/build.gradle.kts
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/AppliedType.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/AppliedType.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/BaseSymbols.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/BaseSymbols.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 @file:OptIn(UnsafeDuringIrConstructionAPI::class)
 
 package dev.zacsweers.moshix.ir.compiler

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiCommandLineProcessor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiCommandLineProcessor.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import com.google.auto.service.AutoService

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiComponentRegistrar.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiComponentRegistrar.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import com.google.auto.service.AutoService

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrGenerationExtension.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import dev.zacsweers.moshix.ir.compiler.util.error

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrUtil.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrUtil.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import com.squareup.moshi.Json

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitor.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import dev.zacsweers.moshix.ir.compiler.api.MoshiAdapterGenerator

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiSymbols.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiSymbols.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 @file:OptIn(UnsafeDuringIrConstructionAPI::class)
 
 package dev.zacsweers.moshix.ir.compiler

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/TargetTypes.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/TargetTypes.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import dev.zacsweers.moshix.ir.compiler.api.TargetConstructor

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/AdapterGenerator.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/AdapterGenerator.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import org.jetbrains.kotlin.ir.declarations.IrClass

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/DelegateKey.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/DelegateKey.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import dev.zacsweers.moshix.ir.compiler.MoshiSymbols

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/MoshiAdapterGenerator.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/MoshiAdapterGenerator.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import dev.zacsweers.moshix.ir.compiler.MoshiSymbols
@@ -279,11 +266,11 @@ internal class MoshiAdapterGenerator(
 
   private fun IrClass.generateOptionsField(): IrField {
     return addField {
-        name = Name.identifier("options")
-        type = irType(ClassId.fromString("com/squareup/moshi/JsonReader.Options"))
-        visibility = DescriptorVisibilities.PRIVATE
-        isFinal = true
-      }
+      name = Name.identifier("options")
+      type = irType(ClassId.fromString("com/squareup/moshi/JsonReader.Options"))
+      visibility = DescriptorVisibilities.PRIVATE
+      isFinal = true
+    }
       .apply {
         initializer =
           pluginContext.createIrBuilder(symbol).run {

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/MoshiOrigin.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/MoshiOrigin.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/PropertyGenerator.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/PropertyGenerator.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import dev.zacsweers.moshix.ir.compiler.util.NameAllocator

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetConstructor.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetConstructor.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetParameter.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetParameter.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import org.jetbrains.kotlin.ir.expressions.IrConstructorCall

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetProperty.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetProperty.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import dev.zacsweers.moshix.ir.compiler.util.type

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetType.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/api/TargetType.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.api
 
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/MoshiSealedOrigin.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/MoshiSealedOrigin.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.sealed
 
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/MoshiSealedSymbols.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/MoshiSealedSymbols.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.sealed
 
 import dev.zacsweers.moshix.ir.compiler.BaseSymbols

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/SealedAdapterGenerator.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/sealed/SealedAdapterGenerator.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.sealed
 
 import dev.zacsweers.moshix.ir.compiler.MoshiSymbols
@@ -382,143 +384,140 @@ private constructor(
         .split(".")
     val adapterName = "${simpleNames.joinToString(separator = "_")}JsonAdapter"
 
-    val adapterCls =
-      buildClass {
-          name = Name.identifier(adapterName)
-          modality = Modality.FINAL
-          kind = ClassKind.CLASS
-          visibility = targetType.visibility // always public or internal
-          origin = MoshiSealedOrigin
+    val adapterCls = buildClass {
+      name = Name.identifier(adapterName)
+      modality = Modality.FINAL
+      kind = ClassKind.CLASS
+      visibility = targetType.visibility // always public or internal
+      origin = MoshiSealedOrigin
+    }
+      .apply {
+        createThisReceiverParameter()
+        val jsonAdapterType =
+          pluginContext
+            .irType(ClassId.fromString("com/squareup/moshi/JsonAdapter"))
+            .classifierOrFail
+            .typeWith(targetType.defaultType)
+        superTypes = listOf(jsonAdapterType)
+        val hasObjectSubtypes = objectSubtypes.isNotEmpty()
+        val ctor =
+          addSimpleDelegatingConstructor(
+              moshiSymbols.jsonAdapter.constructors.single().owner,
+              pluginContext.irBuiltIns,
+              isPrimary = true,
+            )
+            .apply {
+              addValueParameter {
+                name = Name.identifier("moshi")
+                type = moshiSymbols.moshi.defaultType
+              }
+            }
+
+        val runtimeAdapter = addField {
+          name = Name.identifier("runtimeAdapter")
+          type = jsonAdapterType
+          visibility = DescriptorVisibilities.PRIVATE
+          isFinal = true
         }
-        .apply {
-          createThisReceiverParameter()
-          val jsonAdapterType =
-            pluginContext
-              .irType(ClassId.fromString("com/squareup/moshi/JsonAdapter"))
-              .classifierOrFail
-              .typeWith(targetType.defaultType)
-          superTypes = listOf(jsonAdapterType)
-          val hasObjectSubtypes = objectSubtypes.isNotEmpty()
-          val ctor =
-            addSimpleDelegatingConstructor(
-                moshiSymbols.jsonAdapter.constructors.single().owner,
-                pluginContext.irBuiltIns,
-                isPrimary = true,
-              )
-              .apply {
-                addValueParameter {
-                  name = Name.identifier("moshi")
-                  type = moshiSymbols.moshi.defaultType
-                }
-              }
+          .apply {
+            initializer =
+              pluginContext.createIrBuilder(symbol).run {
+                val ofCreatorExpression =
+                  irCall(moshiSealedSymbols.pjafOf).apply {
+                    typeArguments[0] = targetType.defaultType
+                    arguments[0] = moshiSymbols.javaClassReference(this@run, targetType.defaultType)
+                    arguments[1] = irString(labelKey)
+                  }
 
-          val runtimeAdapter =
-            addField {
-                name = Name.identifier("runtimeAdapter")
-                type = jsonAdapterType
-                visibility = DescriptorVisibilities.PRIVATE
-                isFinal = true
-              }
-              .apply {
-                initializer =
-                  pluginContext.createIrBuilder(symbol).run {
-                    val ofCreatorExpression =
-                      irCall(moshiSealedSymbols.pjafOf).apply {
-                        typeArguments[0] = targetType.defaultType
-                        arguments[0] =
-                          moshiSymbols.javaClassReference(this@run, targetType.defaultType)
-                        arguments[1] = irString(labelKey)
+                val moshiParam = ctor.nonDispatchParameters[0]
+                val moshiAccess: IrExpression =
+                  if (hasObjectSubtypes) {
+                    val initial =
+                      irCall(moshiSymbols.moshiNewBuilder).apply {
+                        arguments[0] = irGet(moshiParam)
                       }
-
-                    val moshiParam = ctor.nonDispatchParameters[0]
-                    val moshiAccess: IrExpression =
-                      if (hasObjectSubtypes) {
-                        val initial =
-                          irCall(moshiSymbols.moshiNewBuilder).apply {
-                            arguments[0] = irGet(moshiParam)
-                          }
-                        val newBuilds =
-                          objectSubtypes.fold(initial) { receiver, subtype ->
-                            irCall(moshiSymbols.addAdapter).apply {
-                              typeArguments[0] = subtype.defaultType
-                              arguments[0] = receiver
-                              arguments[1] =
-                                irCall(moshiSealedSymbols.objectJsonAdapterCtor).apply {
-                                  arguments[0] = irGetObject(subtype.symbol)
-                                }
+                    val newBuilds =
+                      objectSubtypes.fold(initial) { receiver, subtype ->
+                        irCall(moshiSymbols.addAdapter).apply {
+                          typeArguments[0] = subtype.defaultType
+                          arguments[0] = receiver
+                          arguments[1] =
+                            irCall(moshiSealedSymbols.objectJsonAdapterCtor).apply {
+                              arguments[0] = irGetObject(subtype.symbol)
                             }
-                          }
-                        irCall(moshiSymbols.moshiBuilderBuild).apply { arguments[0] = newBuilds }
-                      } else {
-                        irGet(moshiParam)
-                      }
-
-                    val subtypesExpression =
-                      subtypes.filterIsInstance<Subtype.ClassType>().fold(ofCreatorExpression) {
-                        receiver,
-                        subtype ->
-                        subtype.labels.fold(receiver) { nestedReceiver, label ->
-                          irCall(moshiSealedSymbols.pjafWithSubtype).apply {
-                            arguments[0] = nestedReceiver
-                            arguments[1] =
-                              moshiSymbols.javaClassReference(
-                                this@run,
-                                subtype.className.defaultType,
-                              )
-                            arguments[2] = irString(label)
-                          }
                         }
                       }
+                    irCall(moshiSymbols.moshiBuilderBuild).apply { arguments[0] = newBuilds }
+                  } else {
+                    irGet(moshiParam)
+                  }
 
-                    var finalFallbackStrategy = fallbackStrategy
-                    subtypes.filterIsInstance<Subtype.ObjectType>().firstOrNull()?.let {
-                      defaultObject ->
-                      if (fallbackStrategy == null) {
-                        finalFallbackStrategy =
-                          FallbackStrategy.DefaultObject(defaultObject.className.symbol)
-                      } else {
-                        logger.error(target) {
-                          "Only one of @DefaultObject, @DefaultNull, or @FallbackJsonAdapter can be used at a time."
-                        }
+                val subtypesExpression =
+                  subtypes.filterIsInstance<Subtype.ClassType>().fold(ofCreatorExpression) {
+                    receiver,
+                    subtype ->
+                    subtype.labels.fold(receiver) { nestedReceiver, label ->
+                      irCall(moshiSealedSymbols.pjafWithSubtype).apply {
+                        arguments[0] = nestedReceiver
+                        arguments[1] =
+                          moshiSymbols.javaClassReference(
+                            this@run,
+                            subtype.className.defaultType,
+                          )
+                        arguments[2] = irString(label)
                       }
                     }
-
-                    val possiblyWithDefaultExpression =
-                      finalFallbackStrategy?.let {
-                        it.statement(
-                          builder = this,
-                          moshiSealedSymbols = moshiSealedSymbols,
-                          subtypesExpression = subtypesExpression,
-                          targetType = targetType.defaultType,
-                          moshiParam = moshiParam,
-                        )
-                      } ?: subtypesExpression
-
-                    // .create(Message::class.java, emptySet(), moshi) as JsonAdapter<Message>
-                    irExprBody(
-                      irAs(
-                        irCall(moshiSymbols.jsonAdapterFactoryCreate).apply {
-                          arguments[0] = possiblyWithDefaultExpression
-                          arguments[1] =
-                            moshiSymbols.javaClassReference(this@run, targetType.defaultType)
-
-                          arguments[2] = irCall(moshiSymbols.emptySet)
-                          arguments[3] = moshiAccess
-                        },
-                        jsonAdapterType,
-                      )
-                    )
                   }
-              }
 
-          generateFromJsonFun(runtimeAdapter)
-          generateToJsonFun(runtimeAdapter)
-          generateToStringFun(
-            pluginContext,
-            simpleNames.joinToString("."),
-            generatedName = "GeneratedSealedJsonAdapter",
-          )
-        }
+                var finalFallbackStrategy = fallbackStrategy
+                subtypes.filterIsInstance<Subtype.ObjectType>().firstOrNull()?.let { defaultObject
+                  ->
+                  if (fallbackStrategy == null) {
+                    finalFallbackStrategy =
+                      FallbackStrategy.DefaultObject(defaultObject.className.symbol)
+                  } else {
+                    logger.error(target) {
+                      "Only one of @DefaultObject, @DefaultNull, or @FallbackJsonAdapter can be used at a time."
+                    }
+                  }
+                }
+
+                val possiblyWithDefaultExpression =
+                  finalFallbackStrategy?.let {
+                    it.statement(
+                      builder = this,
+                      moshiSealedSymbols = moshiSealedSymbols,
+                      subtypesExpression = subtypesExpression,
+                      targetType = targetType.defaultType,
+                      moshiParam = moshiParam,
+                    )
+                  } ?: subtypesExpression
+
+                // .create(Message::class.java, emptySet(), moshi) as JsonAdapter<Message>
+                irExprBody(
+                  irAs(
+                    irCall(moshiSymbols.jsonAdapterFactoryCreate).apply {
+                      arguments[0] = possiblyWithDefaultExpression
+                      arguments[1] =
+                        moshiSymbols.javaClassReference(this@run, targetType.defaultType)
+
+                      arguments[2] = irCall(moshiSymbols.emptySet)
+                      arguments[3] = moshiAccess
+                    },
+                    jsonAdapterType,
+                  )
+                )
+              }
+          }
+
+        generateFromJsonFun(runtimeAdapter)
+        generateToJsonFun(runtimeAdapter)
+        generateToStringFun(
+          pluginContext,
+          simpleNames.joinToString("."),
+          generatedName = "GeneratedSealedJsonAdapter",
+        )
+      }
 
     return PreparedAdapter(adapterCls)
   }

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/util/NameAllocator.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/util/NameAllocator.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2015 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.util
 
 import java.util.UUID

--- a/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/util/ir.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/main/kotlin/dev/zacsweers/moshix/ir/compiler/util/ir.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler.util
 
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext

--- a/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/JavaSuperclass.java
+++ b/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/JavaSuperclass.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler;
 
 public class JavaSuperclass {

--- a/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitorTest.kt
+++ b/moshi-ir/moshi-compiler-plugin/src/test/kotlin/dev/zacsweers/moshix/ir/compiler/MoshiIrVisitorTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.ir.compiler
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-gradle-plugin/build.gradle.kts
+++ b/moshi-ir/moshi-gradle-plugin/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -24,7 +10,6 @@ plugins {
   `java-gradle-plugin`
   alias(libs.plugins.dokka)
   alias(libs.plugins.mavenPublish)
-  alias(libs.plugins.spotless)
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(libs.versions.jdk.get().toInt())) } }
@@ -90,23 +75,6 @@ dokka {
 }
 
 configure<MavenPublishBaseExtension> { publishToMavenCentral(automaticRelease = true) }
-
-spotless {
-  format("misc") {
-    target("*.gradle", "*.md", ".gitignore")
-    trimTrailingWhitespace()
-    leadingTabsToSpaces(2)
-    endWithNewline()
-  }
-  kotlin {
-    target("src/**/*.kt")
-    ktfmt(libs.versions.ktfmt.get()).googleStyle()
-    trimTrailingWhitespace()
-    endWithNewline()
-    licenseHeaderFile("../../spotless/spotless.kt")
-    targetExclude("**/spotless.kt", "build/**")
-  }
-}
 
 dependencies {
   compileOnly(libs.kotlin.gradlePlugin)

--- a/moshi-ir/moshi-gradle-plugin/settings.gradle.kts
+++ b/moshi-ir/moshi-gradle-plugin/settings.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 pluginManagement {
   repositories {
     google()

--- a/moshi-ir/moshi-gradle-plugin/version-templates/Version.kt
+++ b/moshi-ir/moshi-gradle-plugin/version-templates/Version.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 @file:JvmName("Version")
 
 package dev.zacsweers.moshi.ir.gradle

--- a/moshi-ir/moshi-kotlin-tests/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 import java.nio.file.FileSystems
 import kotlin.io.path.deleteIfExists
 import org.gradle.language.base.plugins.LifecycleBasePlugin.BUILD_GROUP

--- a/moshi-ir/moshi-kotlin-tests/extra-moshi-test-module/build.gradle.kts
+++ b/moshi-ir/moshi-kotlin-tests/extra-moshi-test-module/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins { kotlin("jvm") }
 
 dependencies { implementation(libs.moshi) }

--- a/moshi-ir/moshi-kotlin-tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
+++ b/moshi-ir/moshi-kotlin-tests/extra-moshi-test-module/src/main/kotlin/com/squareup/moshi/kotlin/codegen/test/extra/AbstractClassInModuleA.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen.test.extra
 
 import com.squareup.moshi.Json

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/CompileOnlyTests.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/CompileOnlyTests.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.moshi.Json

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/ComplexGenericsInheritanceTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 @file:Suppress("UNUSED", "UNUSED_PARAMETER")
 
 package com.squareup.moshi.kotlin.codegen

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/DefaultConstructorTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2018 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/GeneratedAdaptersTest_CustomGeneratedClassJsonAdapter.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2019 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/LooksLikeAClass/ClassInPackageThatLooksLikeAClass.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/LooksLikeAClass/ClassInPackageThatLooksLikeAClass.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen.LooksLikeAClass
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MixingReflectAndCodeGenTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MixingReflectAndCodeGenTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MoshiKspTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/MultipleMasksTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2019 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/annotation/UppercaseInAnnotationPackage.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/com/squareup/moshi/kotlin/codegen/annotation/UppercaseInAnnotationPackage.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package com.squareup.moshi.kotlin.codegen.annotation
 
 import com.squareup.moshi.FromJson

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/Message.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/Message.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/MessageTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/MessageTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/ObjectSerialization.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/ObjectSerialization.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/ObjectSerializationTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/ObjectSerializationTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/SealedInterfaceMessage.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/SealedInterfaceMessage.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.squareup.moshi.JsonClass

--- a/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/SealedInterfaceMessageTest.kt
+++ b/moshi-ir/moshi-kotlin-tests/src/test/kotlin/dev/zacsweers/moshi/sealed/SealedInterfaceMessageTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshi.sealed
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-metadata-reflect/build.gradle.kts
+++ b/moshi-metadata-reflect/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   kotlin("jvm")
   id("com.google.devtools.ksp")

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/IndexedParameterMap.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/IndexedParameterMap.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 /** A simple [Map] that uses parameter indexes instead of sorting or hashing. */

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/Invokable.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/Invokable.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import com.squareup.moshi.internal.Util.DEFAULT_CONSTRUCTOR_MARKER

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/JvmDescriptors.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/JvmDescriptors.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2025 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import java.lang.reflect.Constructor

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/JvmSignatureSearcher.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/JvmSignatureSearcher.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import java.lang.reflect.Field

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/KmExecutable.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/KmExecutable.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import java.lang.reflect.Constructor

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/KtTypes.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/KtTypes.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2025 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import java.lang.reflect.Field

--- a/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/MetadataKotlinJsonAdapterFactory.kt
+++ b/moshi-metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/reflect/MetadataKotlinJsonAdapterFactory.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2017 Square, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import com.squareup.moshi.Json

--- a/moshi-metadata-reflect/src/test/kotlin/dev/zacsweers/moshix/reflect/JvmDescriptorsTest.kt
+++ b/moshi-metadata-reflect/src/test/kotlin/dev/zacsweers/moshix/reflect/JvmDescriptorsTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-metadata-reflect/src/test/kotlin/dev/zacsweers/moshix/reflect/KotlinJsonAdapterTest.kt
+++ b/moshi-metadata-reflect/src/test/kotlin/dev/zacsweers/moshix/reflect/KotlinJsonAdapterTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2017 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.reflect
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/codegen/build.gradle.kts
+++ b/moshi-sealed/codegen/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.ksp)

--- a/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/KspUtil.kt
+++ b/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/KspUtil.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.codegen.ksp
 
 import com.google.devtools.ksp.processing.Resolver

--- a/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbolProcessorProvider.kt
+++ b/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbolProcessorProvider.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.codegen.ksp
 
 import com.google.auto.service.AutoService

--- a/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbols.kt
+++ b/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbols.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.codegen.ksp
 
 import com.google.devtools.ksp.processing.Resolver

--- a/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/TypeCreation.kt
+++ b/moshi-sealed/codegen/src/main/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/TypeCreation.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.codegen.ksp
 
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/moshi-sealed/codegen/src/test/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbolProcessorTest.kt
+++ b/moshi-sealed/codegen/src/test/kotlin/dev/zacsweers/moshix/sealed/codegen/ksp/MoshiSealedSymbolProcessorTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.codegen.ksp
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/java-sealed-reflect/build.gradle.kts
+++ b/moshi-sealed/java-sealed-reflect/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   `java-library`
   alias(libs.plugins.mavenPublish)

--- a/moshi-sealed/java-sealed-reflect/src/main/java/dev/zacsweers/moshix/sealed/java/JavaSealedJsonAdapterFactory.java
+++ b/moshi-sealed/java-sealed-reflect/src/main/java/dev/zacsweers/moshix/sealed/java/JavaSealedJsonAdapterFactory.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.java;
 
 import static dev.zacsweers.moshix.sealed.runtime.internal.Util.fallbackAdapter;

--- a/moshi-sealed/metadata-reflect/build.gradle.kts
+++ b/moshi-sealed/metadata-reflect/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublish)

--- a/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/metadata-reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MetadataMoshiSealedJsonAdapterFactory.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.reflect
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/reflect/build.gradle.kts
+++ b/moshi-sealed/reflect/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublish)

--- a/moshi-sealed/reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MoshiSealedJsonAdapterFactory.kt
+++ b/moshi-sealed/reflect/src/main/kotlin/dev/zacsweers/moshix/sealed/reflect/MoshiSealedJsonAdapterFactory.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.reflect
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/runtime/build.gradle.kts
+++ b/moshi-sealed/runtime/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublish)

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/DefaultNull.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/DefaultNull.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.annotations
 
 import kotlin.annotation.AnnotationRetention.RUNTIME

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/DefaultObject.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/DefaultObject.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.annotations
 
 import kotlin.annotation.AnnotationRetention.RUNTIME

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/FallbackJsonAdapter.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/FallbackJsonAdapter.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.annotations
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/NestedSealed.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/NestedSealed.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.annotations
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/TypeLabel.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/annotations/TypeLabel.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.annotations
 
 import kotlin.annotation.AnnotationRetention.RUNTIME

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/ObjectJsonAdapter.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/ObjectJsonAdapter.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2019 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.runtime.internal
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/Util.kt
+++ b/moshi-sealed/runtime/src/main/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/Util.kt
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.runtime.internal
 
 import com.squareup.moshi.JsonAdapter

--- a/moshi-sealed/runtime/src/test/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/ObjectJsonAdapterTest.kt
+++ b/moshi-sealed/runtime/src/test/kotlin/dev/zacsweers/moshix/sealed/runtime/internal/ObjectJsonAdapterTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2019 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.runtime.internal
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/sample/build.gradle.kts
+++ b/moshi-sealed/sample/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.ksp)

--- a/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/Message.kt
+++ b/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/Message.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample
 
 import com.squareup.moshi.JsonClass

--- a/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/ObjectSerialization.kt
+++ b/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/ObjectSerialization.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample
 
 import com.squareup.moshi.JsonClass

--- a/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/SealedInterfaceMessage.kt
+++ b/moshi-sealed/sample/src/main/kotlin/dev/zacsweers/moshix/sealed/sample/SealedInterfaceMessage.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample
 
 import com.squareup.moshi.JsonClass

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/MessageTest.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/MessageTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.test
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ObjectSerializationTest.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ObjectSerializationTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.test
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ReflectOnlyTests.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/ReflectOnlyTests.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.test
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/SealedInterfaceMessageTest.kt
+++ b/moshi-sealed/sample/src/test/kotlin/dev/zacsweers/moshix/sealed/sample/test/SealedInterfaceMessageTest.kt
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.test
 
 import com.google.common.truth.Truth.assertThat

--- a/moshi-sealed/sealed-interfaces-samples/java/build.gradle.kts
+++ b/moshi-sealed/sealed-interfaces-samples/java/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins { `java-library` }
 
 val generatedAnnotation = "javax.annotation.processing.Generated"

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/FailureTestCases.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/FailureTestCases.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 import com.squareup.moshi.JsonClass;

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/GenericBoundedRecord.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/GenericBoundedRecord.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 public record GenericBoundedRecord<T extends Number>(T value) {}

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/GenericRecord.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/GenericRecord.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 public record GenericRecord<T>(T value) {}

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageClass.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageClass.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 import com.squareup.moshi.JsonClass;

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageInterface.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageInterface.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 import com.squareup.moshi.JsonClass;

--- a/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageWithNullDefault.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/main/java/dev/zacsweers/moshix/sealed/sample/java/MessageWithNullDefault.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 import com.squareup.moshi.JsonClass;

--- a/moshi-sealed/sealed-interfaces-samples/java/src/test/java/dev/zacsweers/moshix/sealed/sample/java/JavaSealedJsonAdapterFactoryTest.java
+++ b/moshi-sealed/sealed-interfaces-samples/java/src/test/java/dev/zacsweers/moshix/sealed/sample/java/JavaSealedJsonAdapterFactoryTest.java
@@ -1,18 +1,5 @@
-/*
- * Copyright (C) 2021 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 package dev.zacsweers.moshix.sealed.sample.java;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -101,7 +88,8 @@ public final class JavaSealedJsonAdapterFactoryTest {
       assertThat(e)
           .hasMessageThat()
           .contains(
-              "Moshi-sealed subtypes cannot be generic: dev.zacsweers.moshix.sealed.sample.java.FailureTestCases.GenericSubtypes.TypeB");
+              "Moshi-sealed subtypes cannot be generic:"
+                  + " dev.zacsweers.moshix.sealed.sample.java.FailureTestCases.GenericSubtypes.TypeB");
     }
   }
 

--- a/moshix-runtime/build.gradle.kts
+++ b/moshix-runtime/build.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2025 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 plugins {
   alias(libs.plugins.kotlinJvm)
   alias(libs.plugins.mavenPublish)

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,32 @@
   "extends": [
     "config:base"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)\\.kempt\\.toml$"
+      ],
+      "matchStrings": [
+        "\\[ktfmt\\][^\\[]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "maven",
+      "registryUrlTemplate": "https://repo1.maven.org/maven2",
+      "depNameTemplate": "com.facebook:ktfmt"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "(^|/)\\.kempt\\.toml$"
+      ],
+      "matchStrings": [
+        "\\[gjf\\][^\\[]*?version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "maven",
+      "registryUrlTemplate": "https://repo1.maven.org/maven2",
+      "depNameTemplate": "com.google.googlejavaformat:google-java-format"
+    }
+  ],
   "packageRules": [
     {
       "description": "Only update Kotlin artifacts to stable releases.",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,5 @@
-/*
- * Copyright (C) 2020 Zac Sweers
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright (C) 2026 Zac Sweers
+// SPDX-License-Identifier: Apache-2.0
 pluginManagement {
   repositories {
     mavenCentral()

--- a/spotless/spotless.java
+++ b/spotless/spotless.java
@@ -1,2 +1,0 @@
-// Copyright (C) $YEAR Zac Sweers
-// SPDX-License-Identifier: Apache-2.0

--- a/spotless/spotless.kt
+++ b/spotless/spotless.kt
@@ -1,2 +1,0 @@
-// Copyright (C) $YEAR Zac Sweers
-// SPDX-License-Identifier: Apache-2.0

--- a/spotless/spotless.kts
+++ b/spotless/spotless.kts
@@ -1,2 +1,0 @@
-// Copyright (C) $YEAR Zac Sweers
-// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Summary:
- Add Kempt config, license header config, and CI format action.
- Remove Gradle formatting plugin wiring and old formatting templates.
- Add Renovate tracking for Kempt formatter pins.

Tests:
- kempt update
- kempt check --all
- ./gradlew build check -Pmoshix.useKsp=true --quiet
- ./gradlew build check -Pmoshix.useKsp=false --quiet